### PR TITLE
Inferring Features in `feature_select.py`

### DIFF
--- a/pycytominer/correlation_threshold.py
+++ b/pycytominer/correlation_threshold.py
@@ -8,15 +8,16 @@ import pandas as pd
 
 
 def correlation_threshold(
-    population_df, features="none", samples="none", threshold=0.9, method="pearson"
+    population_df, features="infer", samples="none", threshold=0.9, method="pearson"
 ):
     """
     Exclude features that have correlations above a certain threshold
 
     Arguments:
     population_df - pandas DataFrame that includes metadata and observation features
-    features - a list of features present in the population dataframe
-               [default: "none"] - if "none", use all features
+    features - a list of features present in the population dataframe [default: "infer"]
+               if "infer", then assume cell painting features are those that do not
+               start with "Metadata_"
     samples - list samples to perform operation on
               [default: "none"] - if "none", use all samples to calculate
     threshold - float between (0, 1) to exclude features [default: 0.9]
@@ -39,7 +40,11 @@ def correlation_threshold(
     if samples != "none":
         population_df = population_df.loc[samples, :]
 
-    if features != "none":
+    if features == "infer":
+        features = [
+            x for x in population_df.columns.tolist() if not x.startswith("Metadata_")
+        ]
+    else:
         population_df = population_df.loc[:, features]
 
     data_cor_df = population_df.corr(method=method)

--- a/pycytominer/get_na_columns.py
+++ b/pycytominer/get_na_columns.py
@@ -25,7 +25,11 @@ def get_na_columns(population_df, features="none", samples="none", cutoff=0.05):
     if samples != "none":
         population_df = population_df.loc[samples, :]
 
-    if features != "none":
+    if features == "infer":
+        features = [
+            x for x in population_df.columns.tolist() if not x.startswith("Metadata_")
+        ]
+    else:
         population_df = population_df.loc[:, features]
 
     num_rows = population_df.shape[0]

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -8,7 +8,7 @@ from sklearn.preprocessing import StandardScaler, RobustScaler
 
 def normalize(
     profiles,
-    features="none",
+    features="infer",
     meta_features="none",
     samples="all",
     method="standardize",

--- a/pycytominer/tests/test_get_na_columns.py
+++ b/pycytominer/tests/test_get_na_columns.py
@@ -23,7 +23,7 @@ def test_get_na_columns():
     assert get_na_columns_result == expected_result
 
     get_na_columns_result = get_na_columns(
-        population_df=data_df, features="none", cutoff=0.1
+        population_df=data_df, features="infer", cutoff=0.1
     )
     expected_result = ["x", "y", "z", "zz"]
     assert sorted(get_na_columns_result) == expected_result

--- a/pycytominer/variance_threshold.py
+++ b/pycytominer/variance_threshold.py
@@ -8,15 +8,16 @@ import pandas as pd
 
 
 def variance_threshold(
-    population_df, features="none", samples="none", freq_cut=0.05, unique_cut=0.01
+    population_df, features="infer", samples="none", freq_cut=0.05, unique_cut=0.01
 ):
     """
     Exclude features that have correlations below a certain threshold
 
     Arguments:
     population_df - pandas DataFrame that includes metadata and observation features
-    features - a list of features present in the population dataframe
-               [default: "none"] - if "none", use all features
+    features - a list of features present in the population dataframe [default: "infer"]
+               if "infer", then assume cell painting features are those that do not
+               start with "Metadata_"
     samples - list samples to perform operation on
               [default: "none"] - if "none", use all samples to calculate
     freq_cut - float of ratio (second most common feature value / most common) [default: 0.1]
@@ -33,7 +34,11 @@ def variance_threshold(
     if samples != "none":
         population_df = population_df.loc[samples, :]
 
-    if features != "none":
+    if features == "infer":
+        features = [
+            x for x in population_df.columns.tolist() if not x.startswith("Metadata_")
+        ]
+    else:
         population_df = population_df.loc[:, features]
 
     # Test if excluded for low frequency


### PR DESCRIPTION
Switching from "none" default to "infer" default. Expects that all cell painting features do not have "Metadata_" prefixes