### PR TITLE
Output compression to ignore timestamps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: python
+python:
+  - "3.7"
+  - "3.8"
+  - "3.9"
+install:
+- pip install -r requirements.txt
 script:
   - pip install pytest-cov codecov
   - py.test -v --cov-report=xml --cov=pycytominer pycytominer/tests/

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -18,7 +18,7 @@ def aggregate(
     operation="median",
     output_file="none",
     subset_data_df="none",
-    compression=None,
+    compression_options=None,
     float_format=None,
 ):
     """
@@ -79,7 +79,7 @@ def aggregate(
         output(
             df=population_df,
             output_filename=output_file,
-            compression=compression,
+            compression_options=compression_options,
             float_format=float_format,
         )
     else:

--- a/pycytominer/annotate.py
+++ b/pycytominer/annotate.py
@@ -21,7 +21,7 @@ def annotate(
     external_metadata="none",
     external_join_left="none",
     external_join_right="none",
-    compression=None,
+    compression_options=None,
     float_format=None,
 ):
     """
@@ -48,7 +48,7 @@ def annotate(
                         metadata information
     external_join_left - [default: "none"] the merge column in the profile metadata
     external_join_right - [default: "none"] the merge column in the external metadata
-    compression - the mechanism to compress [default: None] See cyto_utils/output.py for options.
+    compression_options - the mechanism to compress [default: None] See cyto_utils/output.py for options.
     float_format - decimal precision to use in writing output file [default: None]
                        For example, use "%.3g" for 3 decimal precision.
 
@@ -180,7 +180,7 @@ def annotate(
         output(
             df=annotated,
             output_filename=output_file,
-            compression=compression,
+            compression_options=compression_options,
             float_format=float_format,
         )
     else:

--- a/pycytominer/consensus.py
+++ b/pycytominer/consensus.py
@@ -20,7 +20,7 @@ def consensus(
     operation="median",
     features="infer",
     output_file="none",
-    compression=None,
+    compression_options=None,
     float_format=None,
     modz_args={"method": "spearman"},
 ):
@@ -38,8 +38,8 @@ def consensus(
     :type output_file: str
     :param modz_args: Additional custom arguments passed as kwargs if operation="modz". See pycytominer.cyto_utils.modz for more details.
     :type modz_args: dict
-    :param compression: the method to compress output data, defaults to None. See pycytominer.cyto_utils.output.py for options
-    :type compression: str
+    :param compression_options: the method to compress output data, defaults to None. See pycytominer.cyto_utils.output.py for options
+    :type compression_options: str
     :param float_format: decimal precision to use in writing output file, defaults to None. For example, use "%.3g" for 3 decimal precision.
 
     :Example:
@@ -102,7 +102,7 @@ def consensus(
         output(
             df=consensus_df,
             output_filename=output_file,
-            compression=compression,
+            compression_options=compression_options,
             float_format=float_format,
         )
     else:

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -319,7 +319,7 @@ class SingleCells(object):
     def merge_single_cells(
         self,
         sc_output_file="none",
-        compression=None,
+        compression_options=None,
         float_format=None,
         single_cell_normalize=False,
         normalize_args=None,
@@ -429,7 +429,7 @@ class SingleCells(object):
             output(
                 df=sc_df,
                 output_filename=sc_output_file,
-                compression=compression,
+                compression_options=compression_options,
                 float_format=float_format,
             )
         else:
@@ -439,7 +439,7 @@ class SingleCells(object):
         self,
         compute_subsample=False,
         output_file="none",
-        compression=None,
+        compression_options=None,
         float_format=None,
         aggregate_args=None,
     ):
@@ -492,7 +492,7 @@ class SingleCells(object):
             output(
                 df=aggregated,
                 output_filename=self.output_file,
-                compression=compression,
+                compression_options=compression_options,
                 float_format=float_format,
             )
         else:

--- a/pycytominer/cyto_utils/output.py
+++ b/pycytominer/cyto_utils/output.py
@@ -6,22 +6,54 @@ import os
 import warnings
 import pandas as pd
 
-compress_options = {"gzip": ".gz", "bz2": ".bz2", "zip": ".zip", "xz": ".xz", None: ""}
+compress_options = {"gzip": ".gz", None: ""}
 
 
 def output(df, output_filename, compression="gzip", float_format=None):
-    """
-    Given an output file and compression options, write file to disk
+    """Given an output file and compression options, write file to disk
 
-    Arguments:
-    df - a pandas dataframe that will be written to file
-    output_filename - a string or path object that stores location of file
-    compression - the mechanism to compress [default: "gzip"]
-    float_format - decimal precision to use in writing output file [default: None]
-                   For example, use "%.3g" for 3 decimal precision.
+    :param df: a pandas dataframe that will be written to file
+    :type df: pandas.DataFrame
+    :param output_filename: a string or path object that stores location of file
+    :type output_filename: str
+    :param output_filename: the mechanism to compress [default: "gzip"]
+    :type output_filename: str
+    :param output_filename: decimal precision to use in writing output file [default: None]
+    :type output_filename: str
 
-    Return:
-    Nothing, write df to file
+    :Example:
+
+    import pandas as pd
+    from pycytominer.cyto_utils import output
+
+    data_df = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "Metadata_Plate": "X",
+                    "Metadata_Well": "a",
+                    "Cells_x": [0.1, 0.3, 0.8],
+                    "Nuclei_y": [0.5, 0.3, 0.1],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "Metadata_Plate": "X",
+                    "Metadata_Well": "b",
+                    "Cells_x": [0.4, 0.2, -0.5],
+                    "Nuclei_y": [-0.8, 1.2, -0.5],
+                }
+            ),
+        ]
+    ).reset_index(drop=True)
+
+    output_file = "test.csv.gz"
+    output(
+        df=data_df,
+        output_filename=output_file,
+        compression="gzip",
+        float_format=None
+    )
     """
 
     # Extract suffixes from the provided output file name

--- a/pycytominer/feature_select.py
+++ b/pycytominer/feature_select.py
@@ -30,7 +30,7 @@ def feature_select(
     corr_method="pearson",
     freq_cut=0.05,
     unique_cut=0.1,
-    compression=None,
+    compression_options=None,
     float_format=None,
     blocklist_file=None,
     outlier_cutoff=15,
@@ -144,7 +144,7 @@ def feature_select(
         output(
             df=selected_df,
             output_filename=output_file,
-            compression=compression,
+            compression_options=compression_options,
             float_format=float_format,
         )
     else:

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -20,7 +20,7 @@ def normalize(
     samples="all",
     method="standardize",
     output_file="none",
-    compression=None,
+    compression_options=None,
     float_format=None,
     spherize_center=True,
     spherize_method="ZCA-cor",
@@ -104,7 +104,7 @@ def normalize(
         output(
             df=normalized,
             output_filename=output_file,
-            compression=compression,
+            compression_options=compression_options,
             float_format=float_format,
         )
     else:

--- a/pycytominer/tests/test_annotate.py
+++ b/pycytominer/tests/test_annotate.py
@@ -75,7 +75,7 @@ def test_annotate_compress():
         join_on=["Metadata_well_position", "Metadata_Well"],
         add_metadata_id_to_platemap=False,
         output_file=compress_file,
-        compression="gzip",
+        compression_options={"method": "gzip"},
     )
 
     result = annotate(

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -389,7 +389,9 @@ def test_aggregate_subsampling_profile():
 def test_aggregate_subsampling_profile_compress():
     compress_file = os.path.join(tmpdir, "test_aggregate_compress.csv.gz")
 
-    _ = ap_subsample.aggregate_profiles(output_file=compress_file, compression="gzip")
+    _ = ap_subsample.aggregate_profiles(
+        output_file=compress_file, compression_options={"method": "gzip"}
+    )
     result = pd.read_csv(compress_file)
 
     expected_result = pd.DataFrame(

--- a/pycytominer/tests/test_cyto_utils/test_output.py
+++ b/pycytominer/tests/test_cyto_utils/test_output.py
@@ -44,7 +44,7 @@ compression_options = {"method": "gzip"}
 
 def test_compress():
 
-    output_filename = os.path.join(tmpdir, "test_compress.csv")
+    output_filename = os.path.join(tmpdir, "test_compress.csv.gz")
 
     output(
         df=data_df,
@@ -52,29 +52,14 @@ def test_compress():
         compression_options=compression_options,
         float_format=None,
     )
-    result = pd.read_csv("{}.gz".format(output_filename))
+    result = pd.read_csv(output_filename)
 
     pd.testing.assert_frame_equal(
         result, data_df, check_names=False, check_less_precise=1
     )
 
 
-def test_compress_no_csv():
-    # Test the ability of a naked string input, appending csv.gz
-    output_filename = os.path.join(tmpdir, "test_compress")
-
-    output(
-        df=data_df,
-        output_filename=output_filename,
-        compression_options=compression_options,
-        float_format=None,
-    )
-    result = pd.read_csv("{}.csv.gz".format(output_filename))
-
-    pd.testing.assert_frame_equal(
-        result, data_df, check_names=False, check_less_precise=1
-    )
-
+def test_compress_tsv():
     # Test input filename of writing a tab separated file
     output_filename = os.path.join(tmpdir, "test_compress.tsv.gz")
     output(

--- a/pycytominer/tests/test_feature_select.py
+++ b/pycytominer/tests/test_feature_select.py
@@ -261,7 +261,7 @@ def test_feature_select_compress():
         features=data_na_df.columns.tolist(),
         operation="drop_na_columns",
         output_file=compress_file,
-        compression="gzip",
+        compression_options={"method": "gzip"},
     )
     expected_result = pd.DataFrame({"yy": [1, 2, 8, 10, 2, 100]})
     result = pd.read_csv(compress_file)

--- a/pycytominer/tests/test_normalize.py
+++ b/pycytominer/tests/test_normalize.py
@@ -411,7 +411,7 @@ def test_normalize_standardize_allsamples_compress():
         samples="all",
         method="standardize",
         output_file=compress_file,
-        compression="gzip",
+        compression_options={"method": "gzip"},
     )
     normalize_result = pd.read_csv(compress_file).round(1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.16.2
+numpy>=1.16.5
 scipy>=1.3.0
 pandas>=1.2.0
 scikit-learn>=0.21.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.16.2
-scipy==1.3.0
+numpy>=1.16.2
+scipy>=1.3.0
 pandas>=1.2.0
-scikit-learn==0.21.2
-sqlalchemy==1.3.6
+scikit-learn>=0.21.2
+sqlalchemy>=1.3.6
 pytest>=5.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.16.2
 scipy==1.3.0
-pandas==0.24.2
+pandas>=1.2.0
 scikit-learn==0.21.2
 sqlalchemy==1.3.6
 pytest>=5.0.1


### PR DESCRIPTION
closes #83 

This is a major, breaking change. If updating pycytominer from an old version to this version, the pipeline will not work.