### PR TITLE
Modify aggregate

### DIFF
--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -41,7 +41,7 @@ def aggregate(
     compute_object_count : bool, default False
         Whether or not to compute object counts.
     object_feature : str, default "ObjectNumber"
-        Object number feature.
+        Object number feature. Only used if compute_object_count=True.
     subset_data_df : pandas.core.frame.DataFrame
         How to subset the input.
     compression_options : str, optional

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -70,6 +70,8 @@ def aggregate(
     else:
         population_df = population_df.mean().reset_index()
 
+    print(list(population_df.columns))
+
     # Aggregated image number and object number do not make sense
     for col in ["ImageNumber", "ObjectNumber"]:
         if col in population_df.columns:

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -48,6 +48,7 @@ def aggregate(
         ).reindex(population_df.columns, axis="columns")
 
     # Subset dataframe to only specified variables if provided
+    print(list(population_df.columns))
     strata_df = population_df.loc[:, strata]
     if features == "infer":
         features = infer_cp_features(population_df)
@@ -69,8 +70,6 @@ def aggregate(
         population_df = population_df.median().reset_index()
     else:
         population_df = population_df.mean().reset_index()
-
-    print(list(population_df.columns))
 
     # Aggregated image number and object number do not make sense
     for col in ["ImageNumber", "ObjectNumber"]:

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -79,7 +79,7 @@ def aggregate(
 
     # Compute objects counts
     if compute_object_count:
-        count_object_df = population_df_copy.loc[:, strata + [object_feature]]
+        count_object_df = population_df_copy.loc[:, np.union1d(strata, [object_feature])]
         count_object_df = (
             count_object_df.groupby(strata)[object_feature]
             .count()

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -51,7 +51,7 @@ def aggregate(
 
     # Subset dataframe to only specified variables if provided
     strata_df = population_df.loc[:, strata]
-    count_df = population_df.loc[:, strata + ['Metadata_ObjectNumber']]
+    count_object_df = population_df.loc[:, strata + ['Metadata_ObjectNumber']]
     if features == "infer":
         features = infer_cp_features(population_df)
         population_df = population_df.loc[:, features]
@@ -75,13 +75,13 @@ def aggregate(
 
     # Compute objects counts
     if compute_object_count:
-        count_df = (
-            count_df.groupby(strata)['Metadata_ObjectNumber']
+        count_object_df = (
+            count_object_df.groupby(strata)['Metadata_ObjectNumber']
             .count()
             .reset_index()
             .rename(columns={'Metadata_ObjectNumber': f'Metadata_Object_Count'})
         )
-        population_df = count_df.merge(population_df, on=strata, how='right')
+        population_df = count_object_df.merge(population_df, on=strata, how='right')
 
 
     # Aggregated image number and object number do not make sense

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -23,25 +23,39 @@ def aggregate(
     compression_options=None,
     float_format=None,
 ):
-    """
-    Combine population dataframe variables by strata groups using given operation
+    """Combine population dataframe variables by strata groups using given operation.
 
-    Arguments:
-    population_df - pandas DataFrame to group and aggregate
-    strata - [default: ["Metadata_Plate", "Metadata_Well"]] list indicating the columns to groupby and aggregate
-    features - [default: "all"] or list indicating features that should be aggregated
-    operation - [default: "median"] a string indicating how the data is aggregated
-                currently only supports one of ['mean', 'median']
-    output_file - [default: "none"] if provided, will write aggregated profiles to file
-                  if not specified, will return the aggregated profiles. We recommend
-                  naming the file based on the plate name.
-    compute_object_count - [default: False] determine whether to compute object counts
-    object_feature - [default: "ObjectNumber"] Object number feature
-    subset_data_df - [default: "none"] a pandas dataframe indicating how to subset the input
+    Parameters
+    ----------
+    population_df : pandas.core.frame.DataFrame
+        DataFrame to group and aggregate.
+    strata : list of str, default ["Metadata_Plate", "Metadata_Well"]
+        Columns to groupby and aggregate.
+    features : list of str, default "all"
+        List of features that should be aggregated.
+    operation : str, default "median"
+        How the data is aggregated. Currently only supports one of ['mean', 'median'].
+    output_file : str or file handle, optional
+        If provided, will write aggregated profiles to file. If not specified, will return the aggregated profiles.
+        We recommend naming the file based on the plate name.
+    compute_object_count : bool, default False
+        Whether or not to compute object counts.
+    object_feature : str, default "ObjectNumber"
+        Object number feature.
+    subset_data_df : pandas.core.frame.DataFrame
+        How to subset the input.
+    compression_options : str, optional
+        The mechanism to compress.
+    float_format : str, optional
+        Decimal precision to use in writing output file.
 
-    Return:
-    Pandas DataFrame of aggregated features
+    Returns
+    -------
+    pandas.core.frame.DataFrame
+        DataFrame of aggregated features.
+
     """
+
     # Check that the operation is supported
     operation = check_aggregate_operation(operation)
 

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -53,7 +53,6 @@ def aggregate(
 
     # Subset dataframe to only specified variables if provided
     strata_df = population_df.loc[:, strata]
-    count_object_df = population_df.loc[:, strata + [object_feature]]
     if features == "infer":
         features = infer_cp_features(population_df)
         population_df = population_df.loc[:, features]
@@ -77,6 +76,7 @@ def aggregate(
 
     # Compute objects counts
     if compute_object_count:
+        count_object_df = population_df.loc[:, strata + [object_feature]]
         count_object_df = (
             count_object_df.groupby(strata)[object_feature]
             .count()

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -75,7 +75,7 @@ def aggregate(
             count_object_df.groupby(strata)[object_feature]
             .count()
             .reset_index()
-            .rename(columns={f"{object_feature}": f"Metadata_Object_Count"})
+            .rename(columns={f"{object_feature}": "Metadata_Object_Count"})
         )
 
     if features == "infer":

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -51,6 +51,9 @@ def aggregate(
             population_df, how="left", on=subset_data_df.columns.tolist()
         ).reindex(population_df.columns, axis="columns")
 
+    # Create a copy of the population dataframe before Metadata features are removed
+    population_df_copy = population_df.copy()
+
     # Subset dataframe to only specified variables if provided
     strata_df = population_df.loc[:, strata]
     if features == "infer":
@@ -76,7 +79,7 @@ def aggregate(
 
     # Compute objects counts
     if compute_object_count:
-        count_object_df = population_df.loc[:, strata + [object_feature]]
+        count_object_df = population_df_copy.loc[:, strata + [object_feature]]
         count_object_df = (
             count_object_df.groupby(strata)[object_feature]
             .count()

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -14,11 +14,11 @@ from pycytominer.cyto_utils import (
 def aggregate(
     population_df,
     strata=["Metadata_Plate", "Metadata_Well"],
-    compute_object_count=False,
-    object_feature="ObjectNumber",
     features="infer",
     operation="median",
     output_file="none",
+    compute_object_count=False,
+    object_feature="ObjectNumber",
     subset_data_df="none",
     compression_options=None,
     float_format=None,
@@ -29,14 +29,14 @@ def aggregate(
     Arguments:
     population_df - pandas DataFrame to group and aggregate
     strata - [default: ["Metadata_Plate", "Metadata_Well"]] list indicating the columns to groupby and aggregate
-    compute_object_count - [default: False] determine whether to compute object counts
-    object_feature - [default: "ObjectNumber"] Object number feature
     features - [default: "all"] or list indicating features that should be aggregated
     operation - [default: "median"] a string indicating how the data is aggregated
                 currently only supports one of ['mean', 'median']
     output_file - [default: "none"] if provided, will write aggregated profiles to file
                   if not specified, will return the aggregated profiles. We recommend
                   naming the file based on the plate name.
+    compute_object_count - [default: False] determine whether to compute object counts
+    object_feature - [default: "ObjectNumber"] Object number feature
     subset_data_df - [default: "none"] a pandas dataframe indicating how to subset the input
 
     Return:

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -15,6 +15,7 @@ def aggregate(
     population_df,
     strata=["Metadata_Plate", "Metadata_Well"],
     compute_object_count=False,
+    object_feature="ObjectNumber",
     features="infer",
     operation="median",
     output_file="none",
@@ -29,6 +30,7 @@ def aggregate(
     population_df - pandas DataFrame to group and aggregate
     strata - [default: ["Metadata_Plate", "Metadata_Well"]] list indicating the columns to groupby and aggregate
     compute_object_count - [default: False] determine whether to compute object counts
+    object_feature - [default: "ObjectNumber"] Object number feature
     features - [default: "all"] or list indicating features that should be aggregated
     operation - [default: "median"] a string indicating how the data is aggregated
                 currently only supports one of ['mean', 'median']
@@ -51,7 +53,7 @@ def aggregate(
 
     # Subset dataframe to only specified variables if provided
     strata_df = population_df.loc[:, strata]
-    count_object_df = population_df.loc[:, strata + ['Metadata_ObjectNumber']]
+    count_object_df = population_df.loc[:, strata + [object_feature]]
     if features == "infer":
         features = infer_cp_features(population_df)
         population_df = population_df.loc[:, features]
@@ -76,13 +78,12 @@ def aggregate(
     # Compute objects counts
     if compute_object_count:
         count_object_df = (
-            count_object_df.groupby(strata)['Metadata_ObjectNumber']
+            count_object_df.groupby(strata)[object_feature]
             .count()
             .reset_index()
-            .rename(columns={'Metadata_ObjectNumber': f'Metadata_Object_Count'})
+            .rename(columns={f'{object_feature}': f'Metadata_Object_Count'})
         )
         population_df = count_object_df.merge(population_df, on=strata, how='right')
-
 
     # Aggregated image number and object number do not make sense
     for col in ["ImageNumber", "ObjectNumber"]:

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -81,9 +81,9 @@ def aggregate(
             count_object_df.groupby(strata)[object_feature]
             .count()
             .reset_index()
-            .rename(columns={f'{object_feature}': f'Metadata_Object_Count'})
+            .rename(columns={f"{object_feature}": f"Metadata_Object_Count"})
         )
-        population_df = count_object_df.merge(population_df, on=strata, how='right')
+        population_df = count_object_df.merge(population_df, on=strata, how="right")
 
     # Aggregated image number and object number do not make sense
     for col in ["ImageNumber", "ObjectNumber"]:

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -79,7 +79,9 @@ def aggregate(
 
     # Compute objects counts
     if compute_object_count:
-        count_object_df = population_df_copy.loc[:, np.union1d(strata, [object_feature])]
+        count_object_df = population_df_copy.loc[
+            :, np.union1d(strata, [object_feature])
+        ]
         count_object_df = (
             count_object_df.groupby(strata)[object_feature]
             .count()

--- a/pycytominer/cyto_utils/__init__.py
+++ b/pycytominer/cyto_utils/__init__.py
@@ -8,7 +8,7 @@ from .util import (
     check_consensus_operation,
     get_pairwise_correlation,
     check_fields_of_view_format,
-    check_fields_of_view
+    check_fields_of_view,
 )
 from .single_cell_ingest_utils import (
     get_default_linking_cols,

--- a/pycytominer/cyto_utils/__init__.py
+++ b/pycytominer/cyto_utils/__init__.py
@@ -7,6 +7,8 @@ from .util import (
     check_aggregate_operation,
     check_consensus_operation,
     get_pairwise_correlation,
+    check_fields_of_view_format,
+    check_fields_of_view
 )
 from .single_cell_ingest_utils import (
     get_default_linking_cols,

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -79,6 +79,7 @@ class SingleCells(object):
         subsample_n="all",
         subsampling_random_state="none",
         fields_of_view="all",
+        fields_of_view_feature = "Metadata_Site",
         object_feature="ObjectNumber",
     ):
         """Constructor method"""
@@ -109,7 +110,7 @@ class SingleCells(object):
         self.compartments = compartments
         self.compartment_linking_cols = compartment_linking_cols
         self.fields_of_view = fields_of_view
-        self.fields_of_view_feature = "Metadata_Site"
+        self.fields_of_view_feature = fields_of_view_feature
         self.object_feature = object_feature
 
         # Confirm that the compartments and linking cols are formatted properly

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -105,7 +105,7 @@ class SingleCells(object):
         self.compartments = compartments
         self.compartment_linking_cols = compartment_linking_cols
         self.fields_of_view = fields_of_view
-        self.fields_of_view_feature = 'Metadata_Site'
+        self.fields_of_view_feature = "Metadata_Site"
         self.object_feature = object_feature
 
         self.image_cols = ["TableNumber", "ImageNumber", "Metadata_Site"]
@@ -183,7 +183,9 @@ class SingleCells(object):
     def load_image(self):
         """Load image table from sqlite file"""
         # Extract image metadata
-        image_query = "select {} from image".format(', '.join(self.image_cols + self.strata))
+        image_query = "select {} from image".format(
+            ", ".join(self.image_cols + self.strata)
+        )
         self.image_df = pd.read_sql(sql=image_query, con=self.conn)
         if self.fields_of_view != "all":
             check_fields_of_view(

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -45,7 +45,7 @@ class SingleCells(object):
     :type subsample_n:, str, int
     :param subsampling_random_state: the random state to init subsample, defaults to "none"
     :type subsampling_random_state: str, int
-    :param fields_of_view: list of field ID to include in the analysis, defaults to "all"
+    :param fields_of_view: list of fields of view to include in the analysis, defaults to "all"
     :type fields_of_view: list, str
 
     .. note::
@@ -123,8 +123,7 @@ class SingleCells(object):
         # Throw an error if both subsample_frac and subsample_n is set
         self._check_subsampling()
 
-        # Confirm that the input fields of view if valid
-
+        # Confirm that the input fields of view is valid
         self.fields_of_view = check_fields_of_view_format(self.fields_of_view)
 
         if self.load_image_data:
@@ -280,7 +279,7 @@ class SingleCells(object):
         return df
 
     def aggregate_compartment(
-        self, compartment, compute_subsample=False, compute_count=False, aggregate_args=None,
+        self, compartment, compute_subsample=False, compute_counts=False, aggregate_args=None,
     ):
         """Aggregate morphological profiles. Uses pycytominer.aggregate()
 
@@ -288,8 +287,8 @@ class SingleCells(object):
         :type compartment: str
         :param compute_subsample: determine if subsample should be computed, defaults to False
         :type compute_subsample: bool
-        :param compute_count: determine if the number of the objects and fields should be computed, defaults to False
-        :type compute_count: bool
+        :param compute_counts: determine if the number of the objects and fields should be computed, defaults to False
+        :type compute_counts: bool
         :param aggregate_args: additional arguments passed as a dictionary as input to pycytominer.aggregate()
         :type aggregate_args: None, dict
         :return: Aggregated single-cell profiles
@@ -327,13 +326,13 @@ class SingleCells(object):
         object_df = aggregate(
             population_df=population_df,
             strata=self.strata,
-            compute_object_count=compute_count,
+            compute_object_count=compute_counts,
             operation=self.aggregation_operation,
             subset_data_df=self.subset_data_df,
             **aggregate_args
         )
 
-        if compute_count:
+        if compute_counts:
             fields_count_df = self.image_df.loc[:, self.strata+['Metadata_Site']]
             fields_count_df = (
                 fields_count_df.groupby(self.strata)['Metadata_Site']
@@ -521,7 +520,7 @@ class SingleCells(object):
         for compartment in self.compartments:
             if compartment_idx == 0:
                 aggregated = self.aggregate_compartment(
-                    compartment=compartment, compute_subsample=compute_subsample, compute_count=True
+                    compartment=compartment, compute_subsample=compute_subsample, compute_counts=True
                 )
             else:
                 aggregated = aggregated.merge(

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -184,7 +184,7 @@ class SingleCells(object):
         """Load image table from sqlite file"""
         # Extract image metadata
         image_query = "select {} from image".format(
-            ", ".join(self.image_cols + self.strata)
+            ", ".join(np.union1d(self.image_cols, self.strata))
         )
         self.image_df = pd.read_sql(sql=image_query, con=self.conn)
         if self.fields_of_view != "all":

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -23,38 +23,42 @@ class SingleCells(object):
     """This is a class to interact with single cell morphological profiles. Interaction
     includes aggregation, normalization, and output.
 
-    :param file_or_conn: A file string or database connection storing the location of single cell profiles
-    :type file_or_conn: str
-    :param strata: The columns to groupby and aggregate single cells, defaults to ["Metadata_Plate", "Metadata_Well"]
-    :type strata: list
-    :param aggregation_operation: operation to perform single cell aggregation, defaults to "median"
-    :type aggregation_operation: str
-    :param output_file: If specified, the location to write the file, defaults to "none"
-    :type output_file: str
-    :param compartments: list of compartments to process, defaults to ["cells", "cytoplasm", "nuclei"]
-    :type compartments: list
-    :param compartment_linking_cols: dictionary identifying how to merge columns across tables, default noted below:
-    :type compartment_linking_cols: dict
-    :param merge_cols: columns indicating how to merge image and compartment data, defaults to ["TableNumber", "ImageNumber"]
-    :type merge_cols: list
-    :param image_cols: columns to select from the image table, defaults to ["TableNumber", "ImageNumber", "Metadata_Site"]
-    :type image_cols: list
-    :param load_image_data: if image data should be loaded into memory, defaults to True
-    :type load_image_data: bool
-    :param subsample_frac: indicating percentage of single cells to select (0 < subsample_frac <= 1), defaults to 1
-    :type subsample_frac: float
-    :param subsample_n: indicate how many samples to subsample - do not specify both subsample_frac and subsample_n, defaults to "all"
-    :type subsample_n:, str, int
-    :param subsampling_random_state: the random state to init subsample, defaults to "none"
-    :type subsampling_random_state: str, int
-    :param fields_of_view: list of fields of view to include in the analysis, defaults to "all"
-    :type fields_of_view: list, str
-    :param object_feature: Object Number feature, defaults to "ObjectNumber"
-    :type object_feature: str
+    Attributes
+    ----------
+    file_or_conn : str or pandas.core.frame.DataFrame
+        A file string or database connection storing the location of single cell profiles.
+    strata : list of str, default ["Metadata_Plate", "Metadata_Well"]
+        The columns to groupby and aggregate single cells.
+    aggregation_operation : str, default "median"
+        Operation to perform single cell aggregation.
+    output_file : str, default "none"
+        If specified, the location to write the file.
+    compartments : list of str, default ["cells", "cytoplasm", "nuclei"]
+        List of compartments to process.
+    compartment_linking_cols : dict, default noted below
+        Dictionary identifying how to merge columns across tables.
+    merge_cols : list of str, default ["TableNumber", "ImageNumber"]
+        Columns indicating how to merge image and compartment data.
+    image_cols : list of str, default ["TableNumber", "ImageNumber", "Metadata_Site"]
+        Columns to select from the image table.
+    load_image_data : bool, default True
+        Whether or not the image data should be loaded into memory.
+    subsample_frac : float, default 1
+        The percentage of single cells to select (0 < subsample_frac <= 1).
+    subsample_n : str or int, default "all"
+        How many samples to subsample - do not specify both subsample_frac and subsample_n.
+    subsampling_random_state : str or int, default "none"
+        The random state to init subsample.
+    fields_of_view : list of int, str, default "all"
+        List of fields of view to aggregate.
+    object_feature : str, default "ObjectNumber"
+        Object number feature.
 
+    Notes
+    -----
     .. note::
         the argument compartment_linking_cols is designed to work with CellProfiler output,
-        as curated by cytominer-database. The defaut is: {
+        as curated by cytominer-database. The default is: {
             "cytoplasm": {
                 "cells": "Cytoplasm_Parent_Cells",
                 "nuclei": "Cytoplasm_Parent_Nuclei",

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -109,7 +109,6 @@ class SingleCells(object):
         self.is_subset_computed = False
         self.compartments = compartments
         self.compartment_linking_cols = compartment_linking_cols
-        self.fields_of_view = fields_of_view
         self.fields_of_view_feature = fields_of_view_feature
         self.object_feature = object_feature
 
@@ -134,7 +133,7 @@ class SingleCells(object):
         self._check_subsampling()
 
         # Confirm that the input fields of view is valid
-        self.fields_of_view = check_fields_of_view_format(self.fields_of_view)
+        self.fields_of_view = check_fields_of_view_format(fields_of_view)
 
         if self.load_image_data:
             self.load_image()

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -108,6 +108,8 @@ class SingleCells(object):
         self.fields_of_view_feature = 'Metadata_Site'
         self.object_feature = object_feature
 
+        self.image_cols = ["TableNumber", "ImageNumber", "Metadata_Site"]
+
         # Confirm that the compartments and linking cols are formatted properly
         assert_linking_cols_complete(
             compartments=self.compartments, linking_cols=self.compartment_linking_cols
@@ -181,10 +183,7 @@ class SingleCells(object):
     def load_image(self):
         """Load image table from sqlite file"""
         # Extract image metadata
-        image_cols = "TableNumber, ImageNumber, Metadata_Site, {}".format(
-            ", ".join(self.strata)
-        )
-        image_query = "select {} from image".format(image_cols)
+        image_query = "select {} from image".format(', '.join(self.image_cols + self.strata))
         self.image_df = pd.read_sql(sql=image_query, con=self.conn)
         if self.fields_of_view != "all":
             check_fields_of_view(

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -79,7 +79,7 @@ class SingleCells(object):
         subsampling_random_state="none",
         fields_of_view="all",
         fields_of_view_feature="Metadata_FieldID",
-        object_feature="ObjectNumber"
+        object_feature="ObjectNumber",
     ):
         """Constructor method"""
         # Check compartments specified
@@ -184,12 +184,19 @@ class SingleCells(object):
     def load_image(self):
         """Load image table from sqlite file"""
         # Extract image metadata
-        image_cols = "TableNumber, ImageNumber, Metadata_Site, {}".format(", ".join(self.strata))
+        image_cols = "TableNumber, ImageNumber, Metadata_Site, {}".format(
+            ", ".join(self.strata)
+        )
         image_query = "select {} from image".format(image_cols)
         self.image_df = pd.read_sql(sql=image_query, con=self.conn)
         if self.fields_of_view != "all":
-            check_fields_of_view(list(np.unique(self.image_df[self.fields_of_view_feature])), list(self.fields_of_view))
-            self.image_df = self.image_df.query(f'{self.fields_of_view_feature}==@self.fields_of_view')
+            check_fields_of_view(
+                list(np.unique(self.image_df[self.fields_of_view_feature])),
+                list(self.fields_of_view),
+            )
+            self.image_df = self.image_df.query(
+                f"{self.fields_of_view_feature}==@self.fields_of_view"
+            )
 
     def count_cells(self, compartment="cells", count_subset=False):
         """Determine how many cells are measured per well.
@@ -287,7 +294,11 @@ class SingleCells(object):
         return df
 
     def aggregate_compartment(
-        self, compartment, compute_subsample=False, compute_counts=False, aggregate_args=None,
+        self,
+        compartment,
+        compute_subsample=False,
+        compute_counts=False,
+        aggregate_args=None,
     ):
         """Aggregate morphological profiles. Uses pycytominer.aggregate()
 
@@ -338,19 +349,23 @@ class SingleCells(object):
             operation=self.aggregation_operation,
             subset_data_df=self.subset_data_df,
             object_feature=self.object_feature,
-            **aggregate_args
+            **aggregate_args,
         )
 
         if compute_counts:
-            fields_count_df = self.image_df.loc[:, self.strata+[self.fields_of_view_feature]]
+            fields_count_df = self.image_df.loc[
+                :, self.strata + [self.fields_of_view_feature]
+            ]
             fields_count_df = (
                 fields_count_df.groupby(self.strata)[self.fields_of_view_feature]
                 .count()
                 .reset_index()
-                .rename(columns={f'{self.fields_of_view_feature}': f'Metadata_Fields_Count'})
+                .rename(
+                    columns={f"{self.fields_of_view_feature}": f"Metadata_Fields_Count"}
+                )
             )
 
-            object_df = fields_count_df.merge(object_df, on=self.strata, how='right')
+            object_df = fields_count_df.merge(object_df, on=self.strata, how="right")
 
         return object_df
 
@@ -529,7 +544,9 @@ class SingleCells(object):
         for compartment in self.compartments:
             if compartment_idx == 0:
                 aggregated = self.aggregate_compartment(
-                    compartment=compartment, compute_subsample=compute_subsample, compute_counts=True
+                    compartment=compartment,
+                    compute_subsample=compute_subsample,
+                    compute_counts=True,
                 )
             else:
                 aggregated = aggregated.merge(

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -354,7 +354,7 @@ class SingleCells(object):
 
         if compute_counts:
             fields_count_df = self.image_df.loc[
-                :, self.strata + [self.fields_of_view_feature]
+                :, list(np.union1d(self.strata, self.fields_of_view_feature))
             ]
             fields_count_df = (
                 fields_count_df.groupby(self.strata)[self.fields_of_view_feature]

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -37,6 +37,8 @@ class SingleCells(object):
     :type compartment_linking_cols: dict
     :param merge_cols: columns indicating how to merge image and compartment data, defaults to ["TableNumber", "ImageNumber"]
     :type merge_cols: list
+    :param image_cols: columns to select from the image table, defaults to ["TableNumber", "ImageNumber", "Metadata_Site"]
+    :type image_cols: list
     :param load_image_data: if image data should be loaded into memory, defaults to True
     :type load_image_data: bool
     :param subsample_frac: indicating percentage of single cells to select (0 < subsample_frac <= 1), defaults to 1
@@ -71,6 +73,7 @@ class SingleCells(object):
         compartments=default_compartments,
         compartment_linking_cols=default_linking_cols,
         merge_cols=["TableNumber", "ImageNumber"],
+        image_cols=["TableNumber", "ImageNumber", "Metadata_Site"],
         load_image_data=True,
         subsample_frac=1,
         subsample_n="all",
@@ -96,6 +99,7 @@ class SingleCells(object):
         self.aggregation_operation = aggregation_operation.lower()
         self.output_file = output_file
         self.merge_cols = merge_cols
+        self.image_cols = image_cols
         self.subsample_frac = subsample_frac
         self.subsample_n = subsample_n
         self.subset_data_df = "none"
@@ -107,8 +111,6 @@ class SingleCells(object):
         self.fields_of_view = fields_of_view
         self.fields_of_view_feature = "Metadata_Site"
         self.object_feature = object_feature
-
-        self.image_cols = ["TableNumber", "ImageNumber", "Metadata_Site"]
 
         # Confirm that the compartments and linking cols are formatted properly
         assert_linking_cols_complete(

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -79,7 +79,7 @@ class SingleCells(object):
         subsample_n="all",
         subsampling_random_state="none",
         fields_of_view="all",
-        fields_of_view_feature = "Metadata_Site",
+        fields_of_view_feature="Metadata_Site",
         object_feature="ObjectNumber",
     ):
         """Constructor method"""
@@ -454,7 +454,7 @@ class SingleCells(object):
             **aggregate_args,
         )
 
-        if compute_counts:
+        if compute_counts and self.fields_of_view_feature not in self.strata:
             fields_count_df = self.image_df.loc[
                 :, list(np.union1d(self.strata, self.fields_of_view_feature))
             ]

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -43,8 +43,8 @@ class SingleCells(object):
     :type subsample_n:, str, int
     :param subsampling_random_state: the random state to init subsample, defaults to "none"
     :type subsampling_random_state: str, int
-    :param fields_of_view: list of fields of view to include in the analysis, defaults to ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
-    :type fields_of_view: list
+    :param fields_of_view: list of field ID to include in the analysis, defaults to "all"
+    :type fields_of_view: list, str
 
     .. note::
         the argument compartment_linking_cols is designed to work with CellProfiler output,
@@ -71,7 +71,7 @@ class SingleCells(object):
         subsample_frac=1,
         subsample_n="all",
         subsampling_random_state="none",
-        fields_of_view=["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        fields_of_view="all"
     ):
         """Constructor method"""
         # Check compartments specified
@@ -174,8 +174,8 @@ class SingleCells(object):
         image_cols = "TableNumber, ImageNumber, Metadata_Site, {}".format(", ".join(self.strata))
         image_query = "select {} from image".format(image_cols)
         self.image_df = pd.read_sql(sql=image_query, con=self.conn)
-        self.image_df.Metadata_Site = self.image_df.Metadata_Site.astype(str)
-        self.image_df = self.image_df.query('Metadata_Site==@self.fields_of_view')
+        if self.fields_of_view != "all":
+            self.image_df = self.image_df.query('Metadata_Site==@self.fields_of_view')
 
     def count_cells(self, compartment="cells", count_subset=False):
         """Determine how many cells are measured per well.

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -443,7 +443,8 @@ class SingleCells(object):
             features = aggregate_args["features"]
 
         aggregate_args["features"] = features
-        aggregate_args["object_feature"] = self.object_feature
+        if "object_feature" not in aggregate_args:
+            aggregate_args["object_feature"] = self.object_feature
 
         object_df = aggregate(
             population_df=population_df,

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -139,35 +139,70 @@ class SingleCells(object):
             self.load_image()
 
     def _check_subsampling(self):
-        """Internal method checking if subsampling options were specified correctly"""
+        """Internal method checking if subsampling options were specified correctly.
+
+        Returns
+        -------
+        None
+            Nothing is returned.
+
+        """
+
         # Check that the user didn't specify both subset frac and subsample all
         assert (
             self.subsample_frac == 1 or self.subsample_n == "all"
         ), "Do not set both subsample_frac and subsample_n"
 
     def set_output_file(self, output_file):
-        """Setting operation to conveniently rename output file
+        """Setting operation to conveniently rename output file.
 
-        :param output_file: the new output file name
-        :type output_file: str
+        Parameters
+        ----------
+        output_file : str
+            New output file name.
+
+        Returns
+        -------
+        None
+            Nothing is returned.
+
         """
+
         self.output_file = output_file
 
     def set_subsample_frac(self, subsample_frac):
-        """Setting operation to conveniently update the subsample fraction
+        """Setting operation to conveniently update the subsample fraction.
 
-        :param subsample_frac: indicating percentage of single cells to select (0 < subsample_frac <= 1), defaults to 1
-        :type subsample_frac: float
+        Parameters
+        ----------
+        subsample_frac : float, default 1
+            Percentage of single cells to select (0 < subsample_frac <= 1).
+
+        Returns
+        -------
+        None
+            Nothing is returned.
+
         """
+
         self.subsample_frac = subsample_frac
         self._check_subsampling()
 
     def set_subsample_n(self, subsample_n):
-        """Setting operation to conveniently update the subsample n
+        """Setting operation to conveniently update the subsample n.
 
-        :param subsample_n: indicate how many samples to subsample - do not specify both subsample_frac and subsample_n, defaults to "all"
-        :type subsample_n:, str, int
+        Parameters
+        ----------
+        subsample_n : int, default "all"
+            Indicate how many sample to subsample - do not specify both subsample_frac and subsample_n.
+
+        Returns
+        -------
+        None
+            Nothing is returned.
+
         """
+
         try:
             self.subsample_n = int(subsample_n)
         except ValueError:
@@ -175,15 +210,32 @@ class SingleCells(object):
         self._check_subsampling()
 
     def set_subsample_random_state(self, random_state):
-        """Setting operation to conveniently update the subsample random state
+        """Setting operation to conveniently update the subsample random state.
 
-        :param random_state: the random state to init subsample, defaults to "none"
-        :type random_state:, str, int
+        Parameters
+        ----------
+        random_state: int, optional
+            The random state to init subsample.
+
+        Returns
+        -------
+        None
+            Nothing is returned.
+
         """
+
         self.subsampling_random_state = random_state
 
     def load_image(self):
-        """Load image table from sqlite file"""
+        """Load image table from sqlite file
+
+        Returns
+        -------
+        None
+            Nothing is returned.
+
+        """
+
         # Extract image metadata
         image_query = "select {} from image".format(
             ", ".join(np.union1d(self.image_cols, self.strata))
@@ -201,12 +253,20 @@ class SingleCells(object):
     def count_cells(self, compartment="cells", count_subset=False):
         """Determine how many cells are measured per well.
 
-        :param compartment: string indicating the compartment to subset, defaults to "cells"
-        :type compartment: str
-        :param count_subset: whether or not count the number of cells as specified by the strata groups
-        :return: A pandas dataframe of cell counts in the experiment
-        :rtype: pd.DataFrame
+        Parameters
+        ----------
+        compartment : str, default "cells"
+            Compartment to subset.
+        count_subset : bool, default False
+            Whether or not count the number of cells as specified by the strata groups.
+
+        Returns
+        -------
+        pandas.core.frame.DataFrame
+            DataFrame of cell counts in the experiment.
+
         """
+
         check_compartments(compartment)
 
         if count_subset:
@@ -234,13 +294,22 @@ class SingleCells(object):
         return count_df
 
     def subsample_profiles(self, df, rename_col=True):
-        """Sample a Pandas DataFrame given subsampling information
+        """Sample a Pandas DataFrame given subsampling information.
 
-        :param df: A single cell profile dataframe
-        :type df: pd.DataFrame
-        :return: A subsampled pandas dataframe of single cell profiles
-        :rtype: pd.DataFrame
+        Parameters
+        ----------
+        df : pandas.core.frame.DataFrame
+            DataFrame of a single cell profile.
+        rename_col : bool, default True
+            Whether or not to rename the columns.
+
+        Returns
+        -------
+        pandas.core.frame.DataFrame
+            A subsampled pandas dataframe of single cell profiles.
+
         """
+
         if self.subsampling_random_state == "none":
             random_state = np.random.randint(0, 10000, size=1)[0]
             self.set_subsample_random_state(random_state)
@@ -264,11 +333,24 @@ class SingleCells(object):
         return output_df
 
     def get_subsample(self, df=None, compartment="cells", rename_col=True):
-        """Apply the subsampling procedure
+        """Apply the subsampling procedure.
 
-        :param compartment: string indicating the compartment to process, defaults to "cells"
-        :type compartment: str
+        Parameters
+        ----------
+        df : pandas.core.frame.DataFrame
+            DataFrame of a single cell profile.
+        compartment : str, default "cells"
+            The compartment to process.
+        rename_col : bool, default True
+            Whether or not to rename the columns.
+
+        Returns
+        -------
+        None
+            Nothing is returned.
+
         """
+
         check_compartments(compartment)
 
         query_cols = "TableNumber, ImageNumber, ObjectNumber"
@@ -289,6 +371,19 @@ class SingleCells(object):
         self.is_subset_computed = True
 
     def load_compartment(self, compartment):
+        """Creates the compartment dataframe.
+
+        Parameters
+        ----------
+        compartment : str
+            The compartment to process.
+
+        Returns
+        -------
+        pandas.core.frame.DataFrame
+            Compartment dataframe.
+
+        """
         compartment_query = "select * from {}".format(compartment)
         df = pd.read_sql(sql=compartment_query, con=self.conn)
         return df
@@ -302,17 +397,24 @@ class SingleCells(object):
     ):
         """Aggregate morphological profiles. Uses pycytominer.aggregate()
 
-        :param compartment: string indicating the specific compartment, defaults to "cells"
-        :type compartment: str
-        :param compute_subsample: determine if subsample should be computed, defaults to False
-        :type compute_subsample: bool
-        :param compute_counts: determine if the number of the objects in each compartment and the number of fields of view per well should be computed, defaults to False
-        :type compute_counts: bool
-        :param aggregate_args: additional arguments passed as a dictionary as input to pycytominer.aggregate()
-        :type aggregate_args: None, dict
-        :return: Aggregated single-cell profiles
-        :rtype: pd.DataFrame
+        Parameters
+        ----------
+        compartment : str, default "cells"
+            Compartment to aggregate.
+        compute_subsample : bool, default False
+            Whether or not to subsample.
+        compute_counts : bool, default False
+            Whether or not to compute the number of objects in each compartment and the number of fields of view per well.
+        aggregate_args : dict, optional
+            Additional arguments passed as input to pycytominer.aggregate().
+
+        Returns
+        -------
+        pandas.core.frame.DataFrame
+            DataFrame of aggregated profiles.
+
         """
+
         check_compartments(compartment)
 
         if (self.subsample_frac < 1 or self.subsample_n != "all") and compute_subsample:
@@ -378,20 +480,28 @@ class SingleCells(object):
         single_cell_normalize=False,
         normalize_args=None,
     ):
-        """Given the linking columns, merge single cell data. Normalization is also supported
+        """Given the linking columns, merge single cell data. Normalization is also supported.
 
-        :param sc_output_file: the name of a file to output, defaults to "none":
-        :type sc_output_file: str, optional
-        :param compression_options: the mechanism to compress, defaults to None
-        :type compression_options: str, optional
-        :param float_format: decimal precision to use in writing output file, defaults to None
-        :type float_format: str, optional
-        :param single_cell_normalize: determine if the single cell data should also be normalized
-        :type single_cell_normalize: bool
-        :param normalize_args: additional arguments passed as a dictionary as input to pycytominer.normalize()
-        :type normalize_args: None, dict
-        :return: Either a dataframe (if output_file="none") or will write to file
-        :rtype: pd.DataFrame, optional
+        Parameters
+        ----------
+        compute_subsample : bool, default False
+            Whether or not to compute subsample.
+        sc_output_file : str, optional
+            The name of a file to output.
+        compression_options : str, optional
+            The mechanism to compress.
+        float_format : str, optional
+            Decimal precision to use in writing output file.
+        single_cell_normalize : bool, default False
+            Whether or not to normalize the single cell data.
+        normalize_args : dict, optional
+            Additional arguments passed as input to pycytominer.normalize().
+
+        Returns
+        -------
+        pandas.core.frame.DataFrame
+            Either a dataframe (if output_file="none") or will write to file.
+
         """
 
         # Load the single cell dataframe by merging on the specific linking columns
@@ -513,28 +623,25 @@ class SingleCells(object):
     ):
         """Aggregate and merge compartments. This is the primary entry to this class.
 
-        :param compute_subsample: Determine if subsample should be computed, defaults to False
-        :type compute_subsample: bool
-        :param output_file: the name of a file to output, defaults to "none"
-        :type output_file: str, optional
-        :param compression_options: the mechanism to compress, defaults to None
-        :type compression_options: str, optional
-        :param float_format: decimal precision to use in writing output file, defaults to None
-        :type float_format: str, optional
-        :param aggregate_args: additional arguments passed as a dictionary as input to pycytominer.aggregate()
-        :type aggregate_args: None, dict
-        :return: Either a dataframe (if output_file="none") or will write to file
-        :rtype: pd.DataFrame, optional
+        Parameters
+        ----------
+        compute_subsample : bool, default False
+            Whether or not to compute subsample. compute_subsample must be specified to perform subsampling.
+            The function aggregate_profiles(compute_subsample=True) will apply subsetting even if subsample is initialized.
+        output_file : str, optional
+            The name of a file to output. We recommended that, if provided, the output file be suffixed with "_augmented".
+        compression_options : str, optional
+            The mechanism to compress.
+        float_format : str, optional
+            Decimal precision to use in writing output file.
+        aggregate_args : dict, optional
+            Additional arguments passed as input to pycytominer.normalize().
 
-        .. note::
-            compute_subsample must be specified to perform subsampling. The function
-            aggregate_profiles(compute_subsample=True) will apply subsetting if even if
-            subsample is initialized
+        Returns
+        -------
+        pandas.core.frame.DataFrame
+            Either a dataframe (if output_file="none") or will write to file.
 
-        .. note::
-            We recommend that, if provided, the output file be suffixed with "_augmented"
-
-        :Example:
         """
 
         if output_file != "none":

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -490,7 +490,7 @@ class SingleCells(object):
         sc_output_file : str, optional
             The name of a file to output.
         compression_options : str, optional
-            The mechanism to compress.
+            Compression arguments as input to pandas.to_csv() with pandas version >= 1.2.
         float_format : str, optional
             Decimal precision to use in writing output file.
         single_cell_normalize : bool, default False
@@ -632,7 +632,7 @@ class SingleCells(object):
         output_file : str, optional
             The name of a file to output. We recommended that, if provided, the output file be suffixed with "_augmented".
         compression_options : str, optional
-            The mechanism to compress.
+            Compression arguments as input to pandas.to_csv() with pandas version >= 1.2.
         float_format : str, optional
             Decimal precision to use in writing output file.
         aggregate_args : dict, optional

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -463,7 +463,7 @@ class SingleCells(object):
                 .count()
                 .reset_index()
                 .rename(
-                    columns={f"{self.fields_of_view_feature}": f"Metadata_Fields_Count"}
+                    columns={f"{self.fields_of_view_feature}": f"Metadata_Site_Count"}
                 )
             )
 

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -399,7 +399,7 @@ class SingleCells(object):
 
         Parameters
         ----------
-        compartment : str, default "cells"
+        compartment : str
             Compartment to aggregate.
         compute_subsample : bool, default False
             Whether or not to subsample.

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -517,8 +517,8 @@ class SingleCells(object):
         :type compute_subsample: bool
         :param output_file: the name of a file to output, defaults to "none"
         :type output_file: str, optional
-        :param compression: the mechanism to compress, defaults to None
-        :type compression: str, optional
+        :param compression_options: the mechanism to compress, defaults to None
+        :type compression_options: str, optional
         :param float_format: decimal precision to use in writing output file, defaults to None
         :type float_format: str, optional
         :param aggregate_args: additional arguments passed as a dictionary as input to pycytominer.aggregate()

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -43,6 +43,8 @@ class SingleCells(object):
     :type subsample_n:, str, int
     :param subsampling_random_state: the random state to init subsample, defaults to "none"
     :type subsampling_random_state: str, int
+    :param fields_of_view: list of fields of view to include in the analysis, defaults to ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+    :type fields_of_view: list
 
     .. note::
         the argument compartment_linking_cols is designed to work with CellProfiler output,
@@ -69,6 +71,7 @@ class SingleCells(object):
         subsample_frac=1,
         subsample_n="all",
         subsampling_random_state="none",
+        fields_of_view=["1", "2", "3", "4", "5", "6", "7", "8", "9"]
     ):
         """Constructor method"""
         # Check compartments specified
@@ -96,6 +99,7 @@ class SingleCells(object):
         self.is_subset_computed = False
         self.compartments = compartments
         self.compartment_linking_cols = compartment_linking_cols
+        self.fields_of_view = fields_of_view
 
         # Confirm that the compartments and linking cols are formatted properly
         assert_linking_cols_complete(
@@ -170,6 +174,8 @@ class SingleCells(object):
         image_cols = "TableNumber, ImageNumber, {}".format(", ".join(self.strata))
         image_query = "select {} from image".format(image_cols)
         self.image_df = pd.read_sql(sql=image_query, con=self.conn)
+        self.image_df.Metadata_Site = self.image_df.Metadata_Site.astype(str)
+        self.image_df = self.image_df.query('Metadata_Site==@self.fields_of_view')
 
     def count_cells(self, compartment="cells", count_subset=False):
         """Determine how many cells are measured per well.

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -341,7 +341,7 @@ class SingleCells(object):
             features = aggregate_args["features"]
 
         aggregate_args["features"] = features
-        aggregate_args['object_feature'] = self.object_feature
+        aggregate_args["object_feature"] = self.object_feature
 
         object_df = aggregate(
             population_df=population_df,

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -306,7 +306,7 @@ class SingleCells(object):
         :type compartment: str
         :param compute_subsample: determine if subsample should be computed, defaults to False
         :type compute_subsample: bool
-        :param compute_counts: determine if the number of the objects and fields should be computed, defaults to False
+        :param compute_counts: determine if the number of the objects in each compartment and the number of fields of view per well should be computed, defaults to False
         :type compute_counts: bool
         :param aggregate_args: additional arguments passed as a dictionary as input to pycytominer.aggregate()
         :type aggregate_args: None, dict

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -47,8 +47,6 @@ class SingleCells(object):
     :type subsampling_random_state: str, int
     :param fields_of_view: list of fields of view to include in the analysis, defaults to "all"
     :type fields_of_view: list, str
-    :param fields_of_view_feature: Fields of view feature name, defaults to "Metadata_FieldID"
-    :type fields_of_view_feature: str
     :param object_feature: Object Number feature, defaults to "ObjectNumber"
     :type object_feature: str
 
@@ -78,7 +76,6 @@ class SingleCells(object):
         subsample_n="all",
         subsampling_random_state="none",
         fields_of_view="all",
-        fields_of_view_feature="Metadata_FieldID",
         object_feature="ObjectNumber",
     ):
         """Constructor method"""
@@ -108,7 +105,7 @@ class SingleCells(object):
         self.compartments = compartments
         self.compartment_linking_cols = compartment_linking_cols
         self.fields_of_view = fields_of_view
-        self.fields_of_view_feature = fields_of_view_feature
+        self.fields_of_view_feature = 'Metadata_Site'
         self.object_feature = object_feature
 
         # Confirm that the compartments and linking cols are formatted properly

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -341,6 +341,7 @@ class SingleCells(object):
             features = aggregate_args["features"]
 
         aggregate_args["features"] = features
+        aggregate_args['object_feature'] = self.object_feature
 
         object_df = aggregate(
             population_df=population_df,
@@ -348,7 +349,6 @@ class SingleCells(object):
             compute_object_count=compute_counts,
             operation=self.aggregation_operation,
             subset_data_df=self.subset_data_df,
-            object_feature=self.object_feature,
             **aggregate_args,
         )
 

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -171,7 +171,7 @@ class SingleCells(object):
     def load_image(self):
         """Load image table from sqlite file"""
         # Extract image metadata
-        image_cols = "TableNumber, ImageNumber, {}".format(", ".join(self.strata))
+        image_cols = "TableNumber, ImageNumber, Metadata_Site, {}".format(", ".join(self.strata))
         image_query = "select {} from image".format(image_cols)
         self.image_df = pd.read_sql(sql=image_query, con=self.conn)
         self.image_df.Metadata_Site = self.image_df.Metadata_Site.astype(str)

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -154,6 +154,7 @@ def check_fields_of_view_format(fields_of_view):
 
 def check_fields_of_view(data_fields_of_view, input_fields_of_view):
     """
+    Confirm that the input list of fields of view is a subset of the list of fields of view in the image table
 
     Arguments:
     data_fields_of_view - list of fields of view in the image table

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -173,7 +173,7 @@ def check_fields_of_view_format(fields_of_view):
 
     Parameters
     ----------
-    fields_of_view : list of int, default "all"
+    fields_of_view : list of int
         List of integer fields of view.
 
     Returns

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -145,9 +145,12 @@ def check_fields_of_view_format(fields_of_view):
             if all(isinstance(x, int) for x in fields_of_view):
                 return fields_of_view
             else:
-                raise TypeError(
-                    f"Variables of type int expected, however some of the input fields of view are not integers"
-                )
+                try:
+                    return list(map(int, fields_of_view))
+                except ValueError:
+                    raise TypeError(
+                        f"Variables of type int expected, however some of the input fields of view are not integers."
+                    )
         else:
             raise TypeError(
                 f"Variable of type list expected, however type {type(fields_of_view)} was passed"

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -196,7 +196,7 @@ def check_fields_of_view_format(fields_of_view):
                     )
         else:
             raise TypeError(
-                f"Variable of type list expected, however type {type(fields_of_view)} was passed"
+                f"Variable of type list expected, however type {type(fields_of_view)} was passed."
             )
     else:
         return fields_of_view
@@ -225,7 +225,7 @@ def check_fields_of_view(data_fields_of_view, input_fields_of_view):
         ) == len(input_fields_of_view)
     except AssertionError:
         raise ValueError(
-            "Some of the input fields of view are not present in the image table"
+            "Some of the input fields of view are not present in the image table."
         )
 
 

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -3,6 +3,7 @@ Miscellaneous utility functions
 """
 
 import os
+import sys
 import warnings
 import numpy as np
 import pandas as pd
@@ -122,6 +123,43 @@ def check_consensus_operation(operation):
         )
 
     return operation
+
+
+def check_fields_of_view_format(fields_of_view):
+    """
+    Confirm that the input fields of view is valid
+
+    Arguments:
+    fields_of_view - "all" or a list of integer fields of view
+
+    Return:
+    Correctly formatted fields_of_view variable
+    """
+
+    if fields_of_view != "all":
+        if isinstance(fields_of_view, list):
+            if all(isinstance(x, int) for x in fields_of_view):
+                return fields_of_view
+            else:
+                raise TypeError(f'Variable of type int expected, however type {type(fields_of_view[0])} was passed')
+        else:
+            raise TypeError(f'Variable of type list expected, however type {type(fields_of_view)} was passed')
+    else:
+        return fields_of_view
+
+
+def check_fields_of_view(data_fields_of_view, input_fields_of_view):
+    """
+
+    Arguments:
+    data_fields_of_view - list of fields of view in the image table
+    input_fields_of_view -  list of input fields of view
+    """
+
+    try:
+        assert(len(list(np.intersect1d(data_fields_of_view, input_fields_of_view))) == len(input_fields_of_view))
+    except AssertionError:
+        raise ValueError('Some of the input fields of view are not present in the image table')
 
 
 def get_pairwise_correlation(population_df, method="pearson"):

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -141,9 +141,13 @@ def check_fields_of_view_format(fields_of_view):
             if all(isinstance(x, int) for x in fields_of_view):
                 return fields_of_view
             else:
-                raise TypeError(f'Variable of type int expected, however type {type(fields_of_view[0])} was passed')
+                raise TypeError(
+                    f"Variable of type int expected, however type {type(fields_of_view[0])} was passed"
+                )
         else:
-            raise TypeError(f'Variable of type list expected, however type {type(fields_of_view)} was passed')
+            raise TypeError(
+                f"Variable of type list expected, however type {type(fields_of_view)} was passed"
+            )
     else:
         return fields_of_view
 
@@ -157,9 +161,13 @@ def check_fields_of_view(data_fields_of_view, input_fields_of_view):
     """
 
     try:
-        assert(len(list(np.intersect1d(data_fields_of_view, input_fields_of_view))) == len(input_fields_of_view))
+        assert len(
+            list(np.intersect1d(data_fields_of_view, input_fields_of_view))
+        ) == len(input_fields_of_view)
     except AssertionError:
-        raise ValueError('Some of the input fields of view are not present in the image table')
+        raise ValueError(
+            "Some of the input fields of view are not present in the image table"
+        )
 
 
 def get_pairwise_correlation(population_df, method="pearson"):

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -126,14 +126,18 @@ def check_consensus_operation(operation):
 
 
 def check_fields_of_view_format(fields_of_view):
-    """
-    Confirm that the input fields of view is valid
+    """Confirm that the input fields of view is valid
 
-    Arguments:
-    fields_of_view - "all" or a list of integer fields of view
+    Parameters
+    ----------
+    fields_of_view : str or list
+        "all" or a list of integer fields of view
 
-    Return:
-    Correctly formatted fields_of_view variable
+    Returns
+    -------
+    str or list
+        Correctly formatted fields_of_view variable
+
     """
 
     if fields_of_view != "all":
@@ -153,12 +157,20 @@ def check_fields_of_view_format(fields_of_view):
 
 
 def check_fields_of_view(data_fields_of_view, input_fields_of_view):
-    """
-    Confirm that the input list of fields of view is a subset of the list of fields of view in the image table
+    """Confirm that the input list of fields of view is a subset of the list of fields of view in the image table
 
-    Arguments:
-    data_fields_of_view - list of fields of view in the image table
-    input_fields_of_view -  list of input fields of view
+    Parameters
+    ----------
+    data_fields_of_view : list
+        List of fields of view in the image table.
+    input_fields_of_view : list
+        List of input fields of view.
+
+    Returns
+    -------
+    None
+        Nothing is returned.
+
     """
 
     try:

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -62,13 +62,13 @@ def check_compartments(compartments):
 
 
 def load_known_metadata_dictionary(metadata_file=default_metadata_file):
-    """From a tab separated text file (two columns: ["compartment", "feature"]) load
+    """From a tab separated text file (two columns: ["compartment", "feature"]), load
     previously known metadata columns per compartment.
 
     Parameters
     ----------
-    metadata_file : str
-        File location of the metadata text file.
+    metadata_file : str, optional
+        File location of the metadata text file. Uses a default dictionary if you do not specify.
 
     Returns
     -------

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -18,10 +18,33 @@ default_metadata_file = os.path.join(
 
 
 def get_default_compartments():
+    """Returns default compartments.
+
+    Returns
+    -------
+    list of str
+        Default compartments.
+
+    """
+
     return ["cells", "cytoplasm", "nuclei"]
 
 
 def check_compartments(compartments):
+    """Checks if the input compartments are non canonical compartments.
+
+    Parameters
+    ----------
+    compartments : list of str
+        Input compartments.
+
+    Returns
+    -------
+    None
+        Nothing is returned.
+
+    """
+
     default_compartments = get_default_compartments()
 
     compartments = convert_compartment_format_to_list(compartments)
@@ -39,16 +62,21 @@ def check_compartments(compartments):
 
 
 def load_known_metadata_dictionary(metadata_file=default_metadata_file):
-    """
-    From a tab separated text file (two columns: ["compartment", "feature"]) load
-    previously known metadata columns per compartment
+    """From a tab separated text file (two columns: ["compartment", "feature"]) load
+    previously known metadata columns per compartment.
 
-    Arguments:
-    metadata_file - file location of the metadata text file
+    Parameters
+    ----------
+    metadata_file : str
+        File location of the metadata text file.
 
-    Output:
-    a dictionary mapping compartments (keys) to previously known metadata (values)
+    Returns
+    -------
+    dict
+        Compartment (keys) mappings to previously known metadata (values).
+
     """
+
     metadata_dict = {}
     with open(metadata_file) as meta_fh:
         next(meta_fh)
@@ -64,15 +92,20 @@ def load_known_metadata_dictionary(metadata_file=default_metadata_file):
 
 
 def check_correlation_method(method):
-    """
-    Confirm that the input method is currently supported
+    """Confirm that the input method is currently supported.
 
-    Arguments:
-    method - string indicating the correlation metric to use
+    Parameters
+    ----------
+    method : str
+        The correlation metric to use.
 
-    Return:
-    Correctly formatted correlation method
+    Returns
+    -------
+    str
+        Correctly formatted correlation method.
+
     """
+
     method = method.lower()
     avail_methods = ["pearson", "spearman", "kendall"]
     assert method in avail_methods, "method {} not supported, select one of {}".format(
@@ -83,15 +116,20 @@ def check_correlation_method(method):
 
 
 def check_aggregate_operation(operation):
-    """
-    Confirm that the input operation for aggregation is currently supported
+    """Confirm that the input operation for aggregation is currently supported.
 
-    Arguments:
-    operation - string indicating the aggregation operation to provide
+    Parameters
+    ----------
+    operation : str
+        Aggregation operation to provide.
 
-    Return:
-    Correctly formatted operation method
+    Returns
+    -------
+    str
+        Correctly formatted operation method.
+
     """
+
     operation = operation.lower()
     avail_ops = ["mean", "median"]
     assert (
@@ -102,15 +140,20 @@ def check_aggregate_operation(operation):
 
 
 def check_consensus_operation(operation):
-    """
-    Confirm that the input operation for consensus is currently supported
+    """Confirm that the input operation for consensus is currently supported.
 
-    Arguments:
-    operation - string indicating the consensus operation to provide
+    Parameters
+    ----------
+    operation: str
+        Consensus operation to provide.
 
-    Return:
-    Correctly formatted operation method
+    Returns
+    -------
+    str
+        Correctly formatted operation method.
+
     """
+
     operation = operation.lower()
     avail_ops = ["modz"]  # All aggregation operations are also supported
     try:
@@ -126,16 +169,16 @@ def check_consensus_operation(operation):
 
 
 def check_fields_of_view_format(fields_of_view):
-    """Confirm that the input fields of view is valid
+    """Confirm that the input fields of view is valid.
 
     Parameters
     ----------
-    fields_of_view : str or list
-        "all" or a list of integer fields of view.
+    fields_of_view : list of int, default "all"
+        List of integer fields of view.
 
     Returns
     -------
-    str or list
+    str or list of int
         Correctly formatted fields_of_view variable.
 
     """
@@ -160,14 +203,14 @@ def check_fields_of_view_format(fields_of_view):
 
 
 def check_fields_of_view(data_fields_of_view, input_fields_of_view):
-    """Confirm that the input list of fields of view is a subset of the list of fields of view in the image table
+    """Confirm that the input list of fields of view is a subset of the list of fields of view in the image table.
 
     Parameters
     ----------
-    data_fields_of_view : list
-        List of fields of view in the image table.
-    input_fields_of_view : list
-        List of input fields of view.
+    data_fields_of_view : list of int
+        Fields of view in the image table.
+    input_fields_of_view : list of int
+        Input fields of view.
 
     Returns
     -------
@@ -187,17 +230,21 @@ def check_fields_of_view(data_fields_of_view, input_fields_of_view):
 
 
 def get_pairwise_correlation(population_df, method="pearson"):
-    """
-    Given a population dataframe, calculate all pairwise correlations
+    """Given a population dataframe, calculate all pairwise correlations.
 
-    Arguments:
-    population_df - pandas DataFrame that includes metadata and observation features
-    method - string indicating which correlation metric to use to test cutoff
-             [default: "pearson"]
+    Parameters
+    ----------
+    population_df : pandas.core.frame.DataFrame
+        Includes metadata and observation features.
+    method : str, default "pearson"
+        Which correlation matrix to use to test cutoff.
+    Returns
+    -------
+    list of str
+        Features to exclude from the population_df.
 
-    Return:
-    list of features to exclude from the population_df
     """
+
     # Check that the input method is supported
     method = check_correlation_method(method)
 

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -146,7 +146,7 @@ def check_fields_of_view_format(fields_of_view):
                 return fields_of_view
             else:
                 raise TypeError(
-                    f"Variable of type int expected, however type {type(fields_of_view[0])} was passed"
+                    f"Variables of type int expected, however some of the input fields of view are not integers"
                 )
         else:
             raise TypeError(

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -31,7 +31,7 @@ def get_default_compartments():
 
 
 def check_compartments(compartments):
-    """Checks if the input compartments are non canonical compartments.
+    """Checks if the input compartments are noncanonical compartments.
 
     Parameters
     ----------

--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -131,12 +131,12 @@ def check_fields_of_view_format(fields_of_view):
     Parameters
     ----------
     fields_of_view : str or list
-        "all" or a list of integer fields of view
+        "all" or a list of integer fields of view.
 
     Returns
     -------
     str or list
-        Correctly formatted fields_of_view variable
+        Correctly formatted fields_of_view variable.
 
     """
 

--- a/pycytominer/tests/test_aggregate.py
+++ b/pycytominer/tests/test_aggregate.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import pytest
 import numpy as np
 import pandas as pd
 from pycytominer import aggregate
@@ -223,3 +224,26 @@ def test_aggregate_compute_object_count():
 
     test_df = pd.read_csv(test_output_file)
     pd.testing.assert_frame_equal(test_df, expected_result)
+
+
+def test_aggregate_incorrect_object_feature():
+    """
+    Testing aggregate pycytominer function
+    """
+
+    incorrect_object_feature = "DOES NOT EXIST"
+
+    with pytest.raises(KeyError) as err:
+        aggregate_result = aggregate(
+            population_df=data_df,
+            strata=["g"],
+            features="infer",
+            operation="median",
+            compute_object_count=True,
+            object_feature=incorrect_object_feature,
+        )
+
+        assert (
+            f"The following labels were missing: Index(['{incorrect_object_feature}'], dtype='object')"
+            in str(err)
+        )

--- a/pycytominer/tests/test_aggregate.py
+++ b/pycytominer/tests/test_aggregate.py
@@ -14,8 +14,22 @@ test_output_file = os.path.join(tmpdir, "test.csv")
 # Build data to use in tests
 data_df = pd.concat(
     [
-        pd.DataFrame({"g": "a", "Cells_x": [1, 3, 8], "Nuclei_y": [5, 3, 1]}),
-        pd.DataFrame({"g": "b", "Cells_x": [1, 3, 5], "Nuclei_y": [8, 3, 1]}),
+        pd.DataFrame(
+            {
+                "g": "a",
+                "ObjectNumber": [1, 2, 3],
+                "Cells_x": [1, 3, 8],
+                "Nuclei_y": [5, 3, 1],
+            }
+        ),
+        pd.DataFrame(
+            {
+                "g": "b",
+                "ObjectNumber": [1, 2, 4],
+                "Cells_x": [1, 3, 5],
+                "Nuclei_y": [8, 3, 1],
+            }
+        ),
     ]
 ).reset_index(drop=True)
 
@@ -158,3 +172,54 @@ def test_aggregate_median_with_missing_values():
     expected_result = expected_result.astype(dtype_convert_dict)
 
     assert aggregate_result.equals(expected_result)
+
+
+def test_aggregate_compute_object_count():
+    """
+    Testing aggregate pycytominer function
+    """
+
+    aggregate_result = aggregate(
+        population_df=data_df,
+        strata=["g"],
+        features="infer",
+        operation="median",
+        compute_object_count=True,
+    )
+
+    expected_result = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "g": "a",
+                    "Metadata_Object_Count": [3],
+                    "Cells_x": [3],
+                    "Nuclei_y": [3],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "g": "b",
+                    "Metadata_Object_Count": [3],
+                    "Cells_x": [3],
+                    "Nuclei_y": [3],
+                }
+            ),
+        ]
+    ).reset_index(drop=True)
+    expected_result = expected_result.astype(dtype_convert_dict)
+
+    assert aggregate_result.equals(expected_result)
+
+    # Test output
+    aggregate(
+        population_df=data_df,
+        strata=["g"],
+        features="infer",
+        operation="median",
+        compute_object_count=True,
+        output_file=test_output_file,
+    )
+
+    test_df = pd.read_csv(test_output_file)
+    pd.testing.assert_frame_equal(test_df, expected_result)

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -64,6 +64,7 @@ image_df = pd.DataFrame(
         "ImageNumber": ["x", "y"],
         "Metadata_Plate": ["plate", "plate"],
         "Metadata_Well": ["A01", "A02"],
+        "Metadata_Site": [1, 1]
     }
 )
 
@@ -98,15 +99,16 @@ new_linking_cols["cytoplasm"]["new"] = "Cytoplasm_Parent_New"
 new_linking_cols["new"] = {"cytoplasm": "ObjectNumber"}
 
 # Setup SingleCells Class
-ap = SingleCells(file_or_conn=file)
+ap = SingleCells(file_or_conn=file, object_feature='Metadata_ObjectNumber')
 ap_subsample = SingleCells(
-    file_or_conn=file, subsample_n=2, subsampling_random_state=123
+    file_or_conn=file, subsample_n=2, subsampling_random_state=123, object_feature='Metadata_ObjectNumber'
 )
 ap_new = SingleCells(
     file_or_conn=new_file,
     load_image_data=False,
     compartments=new_compartments,
     compartment_linking_cols=new_linking_cols,
+    object_feature='Metadata_ObjectNumber',
 )
 
 
@@ -117,7 +119,8 @@ def test_SingleCells_init():
     assert ap.file_or_conn == file
     assert ap.strata == ["Metadata_Plate", "Metadata_Well"]
     assert ap.merge_cols == ["TableNumber", "ImageNumber"]
-    pd.testing.assert_frame_equal(image_df, ap.image_df)
+    assert ap.image_cols == ["TableNumber", "ImageNumber", "Metadata_Site"]
+    pd.testing.assert_frame_equal(image_df.sort_index(axis=1), ap.image_df.sort_index(axis=1))
     assert ap.subsample_frac == 1
     assert ap_subsample.subsample_frac == 1
     assert ap.subsample_n == "all"
@@ -128,6 +131,9 @@ def test_SingleCells_init():
     assert not ap.is_aggregated
     assert ap.subsampling_random_state == "none"
     assert ap_subsample.subsampling_random_state == 123
+    assert ap.fields_of_view == "all"
+    assert ap.fields_of_view_feature == "Metadata_Site"
+    assert ap.object_feature == "Metadata_ObjectNumber"
     assert ap.compartment_linking_cols == get_default_linking_cols()
     assert ap.compartments == get_default_compartments()
 
@@ -244,7 +250,7 @@ def test_merge_single_cells():
                     manual_merge, method=method, samples=samples, features=features
                 )
 
-                pd.testing.assert_frame_equal(norm_method_df, manual_merge_normalize)
+                pd.testing.assert_frame_equal(norm_method_df.sort_index(axis=1), manual_merge_normalize.sort_index(axis=1))
 
     # Test non-canonical compartment merging
     new_sc_merge_df = ap_new.merge_single_cells()
@@ -369,6 +375,8 @@ def test_aggregate_profiles():
         {
             "Metadata_Plate": ["plate", "plate"],
             "Metadata_Well": ["A01", "A02"],
+            "Metadata_Object_Count": [50, 50],
+            "Metadata_Site_Count": [1, 1],
             "Cells_a": [368.0, 583.5],
             "Cells_b": [482.0, 478.5],
             "Cells_c": [531.0, 461.5],
@@ -384,12 +392,12 @@ def test_aggregate_profiles():
         }
     )
 
-    pd.testing.assert_frame_equal(result, expected_result)
+    pd.testing.assert_frame_equal(result.sort_index(axis=1), expected_result.sort_index(axis=1))
 
     # Confirm aggregation after merging single cells
-    sc_aggregated_df = aggregate(ap.merge_single_cells()).sort_index(axis="columns")
+    # sc_aggregated_df = aggregate(ap.merge_single_cells()).sort_index(axis="columns")
 
-    pd.testing.assert_frame_equal(result.sort_index(axis="columns"), sc_aggregated_df)
+    # pd.testing.assert_frame_equal(result.sort_index(axis="columns"), sc_aggregated_df)
 
 
 def test_aggregate_subsampling_count_cells():
@@ -416,50 +424,50 @@ def test_aggregate_subsampling_count_cells():
     pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
 
 
-def test_aggregate_subsampling_profile():
-    result = ap_subsample.aggregate_profiles()
+# def test_aggregate_subsampling_profile():
+#     result = ap_subsample.aggregate_profiles()
+#
+#     expected_subset = pd.DataFrame(
+#         {
+#             "TableNumber": sorted(["x_hash", "y_hash"] * 2),
+#             "ImageNumber": sorted(["x", "y"] * 2),
+#             "Metadata_Plate": ["plate"] * 4,
+#             "Metadata_Well": sorted(["A01", "A02"] * 2),
+#             "Metadata_ObjectNumber": [46, 3] * 2,
+#         }
+#     )
+#
+#     pd.testing.assert_frame_equal(ap_subsample.subset_data_df, expected_subset)
 
-    expected_subset = pd.DataFrame(
-        {
-            "TableNumber": sorted(["x_hash", "y_hash"] * 2),
-            "ImageNumber": sorted(["x", "y"] * 2),
-            "Metadata_Plate": ["plate"] * 4,
-            "Metadata_Well": sorted(["A01", "A02"] * 2),
-            "Metadata_ObjectNumber": [46, 3] * 2,
-        }
-    )
 
-    pd.testing.assert_frame_equal(ap_subsample.subset_data_df, expected_subset)
-
-
-def test_aggregate_subsampling_profile_compress():
-    compress_file = os.path.join(tmpdir, "test_aggregate_compress.csv.gz")
-
-    _ = ap_subsample.aggregate_profiles(
-        output_file=compress_file, compression_options={"method": "gzip"}
-    )
-    result = pd.read_csv(compress_file)
-
-    expected_result = pd.DataFrame(
-        {
-            "Metadata_Plate": ["plate", "plate"],
-            "Metadata_Well": ["A01", "A02"],
-            "Cells_a": [110.0, 680.5],
-            "Cells_b": [340.5, 201.5],
-            "Cells_c": [285.0, 481.0],
-            "Cells_d": [352.0, 549.0],
-            "Cytoplasm_a": [407.5, 705.5],
-            "Cytoplasm_b": [650.0, 439.5],
-            "Cytoplasm_c": [243.5, 78.5],
-            "Cytoplasm_d": [762.5, 625.0],
-            "Nuclei_a": [683.5, 171.0],
-            "Nuclei_b": [50.5, 625.0],
-            "Nuclei_c": [431.0, 483.0],
-            "Nuclei_d": [519.0, 286.5],
-        }
-    )
-
-    pd.testing.assert_frame_equal(result, expected_result)
+# def test_aggregate_subsampling_profile_compress():
+#     compress_file = os.path.join(tmpdir, "test_aggregate_compress.csv.gz")
+#
+#     _ = ap_subsample.aggregate_profiles(
+#         output_file=compress_file, compression_options={"method": "gzip"}
+#     )
+#     result = pd.read_csv(compress_file)
+#
+#     expected_result = pd.DataFrame(
+#         {
+#             "Metadata_Plate": ["plate", "plate"],
+#             "Metadata_Well": ["A01", "A02"],
+#             "Cells_a": [110.0, 680.5],
+#             "Cells_b": [340.5, 201.5],
+#             "Cells_c": [285.0, 481.0],
+#             "Cells_d": [352.0, 549.0],
+#             "Cytoplasm_a": [407.5, 705.5],
+#             "Cytoplasm_b": [650.0, 439.5],
+#             "Cytoplasm_c": [243.5, 78.5],
+#             "Cytoplasm_d": [762.5, 625.0],
+#             "Nuclei_a": [683.5, 171.0],
+#             "Nuclei_b": [50.5, 625.0],
+#             "Nuclei_c": [431.0, 483.0],
+#             "Nuclei_d": [519.0, 286.5],
+#         }
+#     )
+#
+#     pd.testing.assert_frame_equal(result, expected_result)
 
 
 def test_aggregate_count_cells_multiple_strata():
@@ -508,6 +516,7 @@ def test_aggregate_count_cells_multiple_strata():
         file_or_conn=file,
         subsample_n="4",
         strata=["Metadata_Plate", "Metadata_Well", "Metadata_Site"],
+        object_feature="Metadata_ObjectNumber"
     )
 
     count_df = ap_strata.count_cells()

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -457,34 +457,38 @@ def test_aggregate_subsampling_profile():
     pd.testing.assert_frame_equal(ap_subsample.subset_data_df, expected_subset)
 
 
-# def test_aggregate_subsampling_profile_compress():
-#     compress_file = os.path.join(tmpdir, "test_aggregate_compress.csv.gz")
-#
-#     _ = ap_subsample.aggregate_profiles(
-#         output_file=compress_file, compression_options={"method": "gzip"}
-#     )
-#     result = pd.read_csv(compress_file)
-#
-#     expected_result = pd.DataFrame(
-#         {
-#             "Metadata_Plate": ["plate", "plate"],
-#             "Metadata_Well": ["A01", "A02"],
-#             "Cells_a": [110.0, 680.5],
-#             "Cells_b": [340.5, 201.5],
-#             "Cells_c": [285.0, 481.0],
-#             "Cells_d": [352.0, 549.0],
-#             "Cytoplasm_a": [407.5, 705.5],
-#             "Cytoplasm_b": [650.0, 439.5],
-#             "Cytoplasm_c": [243.5, 78.5],
-#             "Cytoplasm_d": [762.5, 625.0],
-#             "Nuclei_a": [683.5, 171.0],
-#             "Nuclei_b": [50.5, 625.0],
-#             "Nuclei_c": [431.0, 483.0],
-#             "Nuclei_d": [519.0, 286.5],
-#         }
-#     )
-#
-#     pd.testing.assert_frame_equal(result, expected_result)
+def test_aggregate_subsampling_profile_compress():
+    compress_file = os.path.join(tmpdir, "test_aggregate_compress.csv.gz")
+
+    _ = ap_subsample.aggregate_profiles(
+        output_file=compress_file,
+        compute_subsample=True,
+        compression_options={"method": "gzip"},
+    )
+    result = pd.read_csv(compress_file)
+
+    expected_result = pd.DataFrame(
+        {
+            "Metadata_Plate": ["plate", "plate"],
+            "Metadata_Well": ["A01", "A02"],
+            "Metadata_Site_Count": [1] * 2,
+            "Metadata_Object_Count": [ap_subsample.subsample_n] * 2,
+            "Cells_a": [110.0, 680.5],
+            "Cells_b": [340.5, 201.5],
+            "Cells_c": [285.0, 481.0],
+            "Cells_d": [352.0, 549.0],
+            "Cytoplasm_a": [407.5, 705.5],
+            "Cytoplasm_b": [650.0, 439.5],
+            "Cytoplasm_c": [243.5, 78.5],
+            "Cytoplasm_d": [762.5, 625.0],
+            "Nuclei_a": [683.5, 171.0],
+            "Nuclei_b": [50.5, 625.0],
+            "Nuclei_c": [431.0, 483.0],
+            "Nuclei_d": [519.0, 286.5],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result, expected_result)
 
 
 def test_aggregate_count_cells_multiple_strata():

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -440,20 +440,21 @@ def test_aggregate_subsampling_count_cells():
     pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
 
 
-# def test_aggregate_subsampling_profile():
-#     result = ap_subsample.aggregate_profiles()
-#
-#     expected_subset = pd.DataFrame(
-#         {
-#             "TableNumber": sorted(["x_hash", "y_hash"] * 2),
-#             "ImageNumber": sorted(["x", "y"] * 2),
-#             "Metadata_Plate": ["plate"] * 4,
-#             "Metadata_Well": sorted(["A01", "A02"] * 2),
-#             "Metadata_ObjectNumber": [46, 3] * 2,
-#         }
-#     )
-#
-#     pd.testing.assert_frame_equal(ap_subsample.subset_data_df, expected_subset)
+def test_aggregate_subsampling_profile():
+    result = ap_subsample.aggregate_profiles(compute_subsample=True)
+
+    expected_subset = pd.DataFrame(
+        {
+            "ImageNumber": sorted(["x", "y"] * 2),
+            "Metadata_Plate": ["plate"] * 4,
+            "Metadata_Site": [1] * 4,
+            "Metadata_Well": sorted(["A01", "A02"] * 2),
+            "TableNumber": sorted(["x_hash", "y_hash"] * 2),
+            "Metadata_ObjectNumber": [46, 3] * 2,
+        }
+    )
+
+    pd.testing.assert_frame_equal(ap_subsample.subset_data_df, expected_subset)
 
 
 # def test_aggregate_subsampling_profile_compress():

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -64,7 +64,7 @@ image_df = pd.DataFrame(
         "ImageNumber": ["x", "y"],
         "Metadata_Plate": ["plate", "plate"],
         "Metadata_Well": ["A01", "A02"],
-        "Metadata_Site": [1, 1]
+        "Metadata_Site": [1, 1],
     }
 )
 
@@ -99,16 +99,19 @@ new_linking_cols["cytoplasm"]["new"] = "Cytoplasm_Parent_New"
 new_linking_cols["new"] = {"cytoplasm": "ObjectNumber"}
 
 # Setup SingleCells Class
-ap = SingleCells(file_or_conn=file, object_feature='Metadata_ObjectNumber')
+ap = SingleCells(file_or_conn=file, object_feature="Metadata_ObjectNumber")
 ap_subsample = SingleCells(
-    file_or_conn=file, subsample_n=2, subsampling_random_state=123, object_feature='Metadata_ObjectNumber'
+    file_or_conn=file,
+    subsample_n=2,
+    subsampling_random_state=123,
+    object_feature="Metadata_ObjectNumber",
 )
 ap_new = SingleCells(
     file_or_conn=new_file,
     load_image_data=False,
     compartments=new_compartments,
     compartment_linking_cols=new_linking_cols,
-    object_feature='Metadata_ObjectNumber',
+    object_feature="Metadata_ObjectNumber",
 )
 
 
@@ -120,7 +123,9 @@ def test_SingleCells_init():
     assert ap.strata == ["Metadata_Plate", "Metadata_Well"]
     assert ap.merge_cols == ["TableNumber", "ImageNumber"]
     assert ap.image_cols == ["TableNumber", "ImageNumber", "Metadata_Site"]
-    pd.testing.assert_frame_equal(image_df.sort_index(axis=1), ap.image_df.sort_index(axis=1))
+    pd.testing.assert_frame_equal(
+        image_df.sort_index(axis=1), ap.image_df.sort_index(axis=1)
+    )
     assert ap.subsample_frac == 1
     assert ap_subsample.subsample_frac == 1
     assert ap.subsample_n == "all"
@@ -250,7 +255,10 @@ def test_merge_single_cells():
                     manual_merge, method=method, samples=samples, features=features
                 )
 
-                pd.testing.assert_frame_equal(norm_method_df.sort_index(axis=1), manual_merge_normalize.sort_index(axis=1))
+                pd.testing.assert_frame_equal(
+                    norm_method_df.sort_index(axis=1),
+                    manual_merge_normalize.sort_index(axis=1),
+                )
 
     # Test non-canonical compartment merging
     new_sc_merge_df = ap_new.merge_single_cells()
@@ -392,7 +400,9 @@ def test_aggregate_profiles():
         }
     )
 
-    pd.testing.assert_frame_equal(result.sort_index(axis=1), expected_result.sort_index(axis=1))
+    pd.testing.assert_frame_equal(
+        result.sort_index(axis=1), expected_result.sort_index(axis=1)
+    )
 
     # Confirm aggregation after merging single cells
     # sc_aggregated_df = aggregate(ap.merge_single_cells()).sort_index(axis="columns")
@@ -516,7 +526,7 @@ def test_aggregate_count_cells_multiple_strata():
         file_or_conn=file,
         subsample_n="4",
         strata=["Metadata_Plate", "Metadata_Well", "Metadata_Site"],
-        object_feature="Metadata_ObjectNumber"
+        object_feature="Metadata_ObjectNumber",
     )
 
     count_df = ap_strata.count_cells()

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -405,9 +405,15 @@ def test_aggregate_profiles():
     )
 
     # Confirm aggregation after merging single cells
-    # sc_aggregated_df = aggregate(ap.merge_single_cells()).sort_index(axis="columns")
+    sc_df = ap.merge_single_cells()
+    sc_aggregated_df = aggregate(
+        sc_df, compute_object_count=True, object_feature="Metadata_ObjectNumber"
+    ).sort_index(axis="columns")
 
-    # pd.testing.assert_frame_equal(result.sort_index(axis="columns"), sc_aggregated_df)
+    pd.testing.assert_frame_equal(
+        result.sort_index(axis="columns").drop("Metadata_Site_Count", axis="columns"),
+        sc_aggregated_df,
+    )
 
 
 def test_aggregate_subsampling_count_cells():

--- a/pycytominer/tests/test_cyto_utils/test_util.py
+++ b/pycytominer/tests/test_cyto_utils/test_util.py
@@ -163,25 +163,37 @@ def test_check_fields_of_view():
     invalid_input_fields_of_view = [2, 6, 7]
     with pytest.raises(ValueError) as err:
         check_fields_of_view(data_fields_of_view, invalid_input_fields_of_view)
-        assert str(err) == "Some of the input fields of view are not present in the image table."
+        assert (
+            str(err)
+            == "Some of the input fields of view are not present in the image table."
+        )
 
 
 def test_check_fields_of_view_format():
     valid_input_fields_of_view = "all"
-    assert check_fields_of_view_format(valid_input_fields_of_view) == valid_input_fields_of_view
+    assert (
+        check_fields_of_view_format(valid_input_fields_of_view)
+        == valid_input_fields_of_view
+    )
 
-    valid_input_fields_of_view = ['1', 3, 4]
+    valid_input_fields_of_view = ["1", 3, 4]
     assert check_fields_of_view_format(valid_input_fields_of_view) == [1, 3, 4]
 
-    valid_input_fields_of_view = ['3', '1', '5']  # valid but not recommended
+    valid_input_fields_of_view = ["3", "1", "5"]  # valid but not recommended
     assert check_fields_of_view_format(valid_input_fields_of_view) == [3, 1, 5]
 
     invalid_input_fields_of_view = 1
     with pytest.raises(TypeError) as err:
         check_fields_of_view_format(invalid_input_fields_of_view)
-        assert str(err) == f"Variable of type list expected, however type {type(invalid_input_fields_of_view)} was passed."
+        assert (
+            str(err)
+            == f"Variable of type list expected, however type {type(invalid_input_fields_of_view)} was passed."
+        )
 
-    invalid_input_fields_of_view = ['test', 2, 3]
+    invalid_input_fields_of_view = ["test", 2, 3]
     with pytest.raises(TypeError) as err:
         check_fields_of_view_format(invalid_input_fields_of_view)
-        assert str(err) == "Variables of type int expected, however some of the input fields of view are not integers."
+        assert (
+            str(err)
+            == "Variables of type int expected, however some of the input fields of view are not integers."
+        )

--- a/pycytominer/tests/test_cyto_utils/test_util.py
+++ b/pycytominer/tests/test_cyto_utils/test_util.py
@@ -12,6 +12,8 @@ from pycytominer.cyto_utils.util import (
     check_correlation_method,
     check_aggregate_operation,
     check_consensus_operation,
+    check_fields_of_view,
+    check_fields_of_view_format,
 )
 
 tmpdir = tempfile.gettempdir()
@@ -144,3 +146,42 @@ def test_get_pairwise_correlation():
     expected_result = -0.8
     x_y_cor = pair_df.query("correlation != 0").round(1).correlation.values[0]
     assert x_y_cor == expected_result
+
+
+def test_check_fields_of_view():
+    data_fields_of_view = [1, 3, 4, 5]
+
+    valid_input_fields_of_view = [1, 3, 4]
+    assert check_fields_of_view(data_fields_of_view, valid_input_fields_of_view) is None
+
+    valid_input_fields_of_view = [5, 4, 1]
+    assert check_fields_of_view(data_fields_of_view, valid_input_fields_of_view) is None
+
+    valid_input_fields_of_view = [4, 3, 1, 5]
+    assert check_fields_of_view(data_fields_of_view, valid_input_fields_of_view) is None
+
+    invalid_input_fields_of_view = [2, 6, 7]
+    with pytest.raises(ValueError) as err:
+        check_fields_of_view(data_fields_of_view, invalid_input_fields_of_view)
+        assert str(err) == "Some of the input fields of view are not present in the image table."
+
+
+def test_check_fields_of_view_format():
+    valid_input_fields_of_view = "all"
+    assert check_fields_of_view_format(valid_input_fields_of_view) == valid_input_fields_of_view
+
+    valid_input_fields_of_view = ['1', 3, 4]
+    assert check_fields_of_view_format(valid_input_fields_of_view) == [1, 3, 4]
+
+    valid_input_fields_of_view = ['3', '1', '5']  # valid but not recommended
+    assert check_fields_of_view_format(valid_input_fields_of_view) == [3, 1, 5]
+
+    invalid_input_fields_of_view = 1
+    with pytest.raises(TypeError) as err:
+        check_fields_of_view_format(invalid_input_fields_of_view)
+        assert str(err) == f"Variable of type list expected, however type {type(invalid_input_fields_of_view)} was passed."
+
+    invalid_input_fields_of_view = ['test', 2, 3]
+    with pytest.raises(TypeError) as err:
+        check_fields_of_view_format(invalid_input_fields_of_view)
+        assert str(err) == "Variables of type int expected, however some of the input fields of view are not integers."


### PR DESCRIPTION
In this PR, I attempt to add the following functionalities to pycytominer

- Aggregate profiles from only specific sites - https://github.com/cytomining/pycytominer/issues/123 
- Add object count and number of sites to the profiles as per Anne and Shantanu's request on Slack

> Anne: we really should have a bit of QC in the pipeline for each experiment that says how mean cells/sample and sites/sample to be sure that checks out.

> Shantanu: would it be possible to add (counts, number of sites) as outputs of https://github.com/jump-cellpainting/profiling-recipe/blob/refactor_recipe/profiles/profile.py

Instead of outputting the counts separately, I have added them as metadata to the profiles.

### Things changed/added

The following is the description of things I added/changed to the code

#### `pycytominer/aggregate.py`
- `aggregate`
	- Added the parameters `compute_object_count` and `object_feature` to the `aggregate` function.
		- `compute_object_count` defaults to False. This tells `aggregate` whether to count objects or not.
		- `object_feature` defaults to `ObjectNumber`. This stores the name of the metadata feature that distinguishes objects. I believe `ObjectNumber` is used in CellProfiler4 (I need to confirm this). In an older dataset I found this feature's name to be `Metadata_ObjectNumber`.
	- Added code to compute the number of objects. A new metadata feature `Metadata_Object_Count` is added to the profile with the number of objects per sample. 

#### `pycytominer/cyto_utils/util.py`
- Added two functions `check_fields_of_view_format` and `check_fields_of_view`.
	- `check_fields_of_view_format` checks if the input fields of view is an array of integers. If not, it raises TypeError.
	- `check_fields_of_view` checks to ensure that the entered list of fields of view is a subset of the fields of view in the data. If not, it raises a ValueError.

#### `pycytominer/cyto_utils/__init__.py`
- Added the functions `check_fields_of_view_format` and `check_fields_of_view`.

#### `pycytominer/cyto_utils/cells.py`
- `__init__`
	- Imported the functions `check_fields_of_view_format` and `check_fields_of_view` in `pycytominer/cyto_utils/cells.py`.
	- Added the parameters `fields_of_view`, `fields_of_view_feature` and `object_feature`.
		- `fields_of_view` defaults to `all`. This stores the list of fields of view input by the user.
		- `fields_of_view_feature` defaults to `Metadata_FieldID`. This stores the name of the field of view metadata feature. In older data `Metadata_Site` 
		- `object_feature` defaults to `ObjectNumber`. This stores the name of the object number metadata feature.
	- If the user inputs custom fields of view, then `check_fields_of_view_format` is called to check if the input format is correct.
- `load_image`
	- Functionality is added to filter out fields based on the value of `fields_of_view`.
		- `check_fields_of_view` is called to ensure the input fields of view is a subset of the fields of view available in the data before fields are filtered out.
- `aggregate_compartment`
	- Added the parameter `compute_count`. 
		- `compute_count` defaults to False. It should be set to True only when object count and field of view count should be added to the profiles.
		- Added code to compute the number of fields of view. A new metadata feature `Metadata_Fields_Count` is added to the profile with the number of fields of view per sample.
- `aggregate_profiles`
	- When the `aggregate_compartment` is called for the first time, `compute_counts` is set to True. This assumes that the object count is the same for all compartments (@shntnu Is it true that the object count is same for all compartments?)

#### Minor changes

- In the docstring of the function `merge_single_cells` in `pycytominer/cyto_utils/cell.py` I fixed a typo by changing `compression` to changed to `compression_options`.


### Example

I took a single plate of data from @gwaygenomics's pipeline example - https://github.com/cytomining/pipeline-examples/blob/main/0.download.sh and tested the modifications above. The following is an example of how to specify the fields to view to aggregate and how the profiles look like. In the first example only 3 fields are aggregated. In the second example all the available fields are aggregated.

https://nbviewer.jupyter.org/github/niranjchandrasekaran/explore-aggregate/blob/main/run-aggregate.ipynb (I have given up on GitHub's ability to display Jupyter notebooks)

### Things not yet done
Anne had also asked to add the number of channels.

> Anne: And also number of channels (for when we wonder if we had brifghtfield or not)

I was not able to find this information in the sqlite file. @shntnu, I know that we can get this information from the Image.idx.xml file ([like I had done previously](https://github.com/jump-cellpainting/pilot-analysis/issues/41)) but since pycytominer does not interact with the xml file, I was wondering if there is another way to do this.