### PR TITLE
Set default object_feature to Metadata_ObjectNumber

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,13 +6,11 @@ Thank you for your contribution to pycytominer!
 Please _succinctly_ summarize your proposed change.
 What motivated you to make this change?
 
-In https://github.com/cytomining/pycytominer/pull/129 the default feature that distinguishes object was set to `ObjectNumber` instead of `Metadata_ObjectNumber` assuming the CellProfiler4 uses the former. While working on new datasets, I realized that this wasn't the case. 
-
-In this PR, I set the default feature name to `ObjectNumber`. Both `cyto_utils/cells.SingleCells()` and `aggregate.aggregate()` will continue to allow user input name for this feature in case it is needed.
+Please also link to any relevant issues that your code is associated with.
 
 ## What is the nature of your change?
 
-- [x] Bug fix (fixes an issue).
+- [ ] Bug fix (fixes an issue).
 - [ ] Enhancement (adds functionality).
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
 - [ ] This change requires a documentation update.
@@ -21,12 +19,12 @@ In this PR, I set the default feature name to `ObjectNumber`. Both `cyto_utils/c
 
 Please ensure that all boxes are checked before indicating that a pull request is ready for review.
 
-- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
-- [x] My code follows the style guidelines of this project.
-- [x] I have performed a self-review of my own code.
-- [x] I have commented my code, particularly in hard-to-understand areas.
-- [x] I have made corresponding changes to the documentation.
-- [x] My changes generate no new warnings.
-- [x] New and existing unit tests pass locally with my changes.
-- [x] I have added tests that prove my fix is effective or that my feature works.
-- [x] I have deleted all non-relevant text in this pull request template.
+- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
+- [ ] My code follows the style guidelines of this project.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have commented my code, particularly in hard-to-understand areas.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] My changes generate no new warnings.
+- [ ] New and existing unit tests pass locally with my changes.
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] I have deleted all non-relevant text in this pull request template.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,11 +6,13 @@ Thank you for your contribution to pycytominer!
 Please _succinctly_ summarize your proposed change.
 What motivated you to make this change?
 
-Please also link to any relevant issues that your code is associated with.
+In https://github.com/cytomining/pycytominer/pull/129 the default feature that distinguishes object was set to `ObjectNumber` instead of `Metadata_ObjectNumber` assuming the CellProfiler4 uses the former. While working on new datasets, I realized that this wasn't the case. 
+
+In this PR, I set the default feature name to `ObjectNumber`. Both `cyto_utils/cells.SingleCells()` and `aggregate.aggregate()` will continue to allow user input name for this feature in case it is needed.
 
 ## What is the nature of your change?
 
-- [ ] Bug fix (fixes an issue).
+- [x] Bug fix (fixes an issue).
 - [ ] Enhancement (adds functionality).
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
 - [ ] This change requires a documentation update.
@@ -19,12 +21,12 @@ Please also link to any relevant issues that your code is associated with.
 
 Please ensure that all boxes are checked before indicating that a pull request is ready for review.
 
-- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
-- [ ] My code follows the style guidelines of this project.
-- [ ] I have performed a self-review of my own code.
-- [ ] I have commented my code, particularly in hard-to-understand areas.
-- [ ] I have made corresponding changes to the documentation.
-- [ ] My changes generate no new warnings.
-- [ ] New and existing unit tests pass locally with my changes.
-- [ ] I have added tests that prove my fix is effective or that my feature works.
-- [ ] I have deleted all non-relevant text in this pull request template.
+- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
+- [x] My code follows the style guidelines of this project.
+- [x] I have performed a self-review of my own code.
+- [x] I have commented my code, particularly in hard-to-understand areas.
+- [x] I have made corresponding changes to the documentation.
+- [x] My changes generate no new warnings.
+- [x] New and existing unit tests pass locally with my changes.
+- [x] I have added tests that prove my fix is effective or that my feature works.
+- [x] I have deleted all non-relevant text in this pull request template.

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -18,7 +18,7 @@ def aggregate(
     operation="median",
     output_file="none",
     compute_object_count=False,
-    object_feature="ObjectNumber",
+    object_feature="Metadata_ObjectNumber",
     subset_data_df="none",
     compression_options=None,
     float_format=None,
@@ -40,7 +40,7 @@ def aggregate(
         We recommend naming the file based on the plate name.
     compute_object_count : bool, default False
         Whether or not to compute object counts.
-    object_feature : str, default "ObjectNumber"
+    object_feature : str, default "Metadata_ObjectNumber"
         Object number feature. Only used if compute_object_count=True.
     subset_data_df : pandas.core.frame.DataFrame
         How to subset the input.

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -51,7 +51,7 @@ class SingleCells(object):
         The random state to init subsample.
     fields_of_view : list of int, str, default "all"
         List of fields of view to aggregate.
-    object_feature : str, default "ObjectNumber"
+    object_feature : str, default "Metadata_ObjectNumber"
         Object number feature.
 
     Notes
@@ -84,7 +84,7 @@ class SingleCells(object):
         subsampling_random_state="none",
         fields_of_view="all",
         fields_of_view_feature="Metadata_Site",
-        object_feature="ObjectNumber",
+        object_feature="Metadata_ObjectNumber",
     ):
         """Constructor method"""
         # Check compartments specified

--- a/pycytominer/tests/test_aggregate.py
+++ b/pycytominer/tests/test_aggregate.py
@@ -266,14 +266,14 @@ def test_aggregate_incorrect_object_feature():
     assert result.shape[0] == 3
 
 
-def test_alternate_objectnumber_feature():
+def test_custom_objectnumber_feature():
     """
     Testing aggregate pycytominer function
     """
 
     data_df_copy = (
         data_df.copy()
-        .rename(columns={'Metadata_ObjectNumber': 'Alternate_ObjectNumber_Feature'})
+        .rename(columns={'Metadata_ObjectNumber': 'Custom_ObjectNumber_Feature'})
     )
 
     aggregate_result = aggregate(
@@ -282,7 +282,7 @@ def test_alternate_objectnumber_feature():
         features="infer",
         operation="median",
         compute_object_count=True,
-        object_feature='Alternate_ObjectNumber_Feature'
+        object_feature='Custom_ObjectNumber_Feature'
     )
 
     expected_result = pd.concat(

--- a/pycytominer/tests/test_aggregate.py
+++ b/pycytominer/tests/test_aggregate.py
@@ -18,7 +18,7 @@ data_df = pd.concat(
         pd.DataFrame(
             {
                 "g": "a",
-                "ObjectNumber": [1, 2, 3],
+                "Metadata_ObjectNumber": [1, 2, 3],
                 "Cells_x": [1, 3, 8],
                 "Nuclei_y": [5, 3, 1],
             }
@@ -26,7 +26,7 @@ data_df = pd.concat(
         pd.DataFrame(
             {
                 "g": "b",
-                "ObjectNumber": [1, 2, 4],
+                "Metadata_ObjectNumber": [1, 2, 4],
                 "Cells_x": [1, 3, 5],
                 "Nuclei_y": [8, 3, 1],
             }

--- a/pycytominer/tests/test_aggregate.py
+++ b/pycytominer/tests/test_aggregate.py
@@ -264,3 +264,47 @@ def test_aggregate_incorrect_object_feature():
     )
     # There should be three total groups
     assert result.shape[0] == 3
+
+
+def test_alternate_objectnumber_feature():
+    """
+    Testing aggregate pycytominer function
+    """
+
+    data_df_copy = (
+        data_df.copy()
+        .rename(columns={'Metadata_ObjectNumber': 'Alternate_ObjectNumber_Feature'})
+    )
+
+    aggregate_result = aggregate(
+        population_df=data_df_copy,
+        strata=["g"],
+        features="infer",
+        operation="median",
+        compute_object_count=True,
+        object_feature='Alternate_ObjectNumber_Feature'
+    )
+
+    expected_result = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "g": "a",
+                    "Metadata_Object_Count": [3],
+                    "Cells_x": [3],
+                    "Nuclei_y": [3],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "g": "b",
+                    "Metadata_Object_Count": [3],
+                    "Cells_x": [3],
+                    "Nuclei_y": [3],
+                }
+            ),
+        ]
+    ).reset_index(drop=True)
+    expected_result = expected_result.astype(dtype_convert_dict)
+
+    assert aggregate_result.equals(expected_result)

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -99,19 +99,17 @@ new_linking_cols["cytoplasm"]["new"] = "Cytoplasm_Parent_New"
 new_linking_cols["new"] = {"cytoplasm": "ObjectNumber"}
 
 # Setup SingleCells Class
-ap = SingleCells(file_or_conn=file, object_feature="Metadata_ObjectNumber")
+ap = SingleCells(file_or_conn=file)
 ap_subsample = SingleCells(
     file_or_conn=file,
     subsample_n=2,
     subsampling_random_state=123,
-    object_feature="Metadata_ObjectNumber",
 )
 ap_new = SingleCells(
     file_or_conn=new_file,
     load_image_data=False,
     compartments=new_compartments,
     compartment_linking_cols=new_linking_cols,
-    object_feature="Metadata_ObjectNumber",
 )
 
 
@@ -407,7 +405,7 @@ def test_aggregate_profiles():
     # Confirm aggregation after merging single cells
     sc_df = ap.merge_single_cells()
     sc_aggregated_df = aggregate(
-        sc_df, compute_object_count=True, object_feature="Metadata_ObjectNumber"
+        sc_df, compute_object_count=True
     ).sort_index(axis="columns")
 
     pd.testing.assert_frame_equal(
@@ -537,7 +535,6 @@ def test_aggregate_count_cells_multiple_strata():
         file_or_conn=file,
         subsample_n="4",
         strata=["Metadata_Plate", "Metadata_Well", "Metadata_Site"],
-        object_feature="Metadata_ObjectNumber",
     )
 
     count_df = ap_strata.count_cells()


### PR DESCRIPTION
_modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_

# Description

Thank you for your contribution to pycytominer!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

In https://github.com/cytomining/pycytominer/pull/129, the default feature that distinguishes objects was set to `ObjectNumber` instead of `Metadata_ObjectNumber` assuming that CellProfiler4 uses the former. While working on new datasets, I realized that this wasn't the case.

In this PR, I set the default feature name to `Metadata_ObjectNumber`. Both `cyto_utils/cells.SingleCells()` and `aggregate.aggregate()` will continue to allow user input name for this feature, in case that is needed.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
