### PR TITLE
Add github action to publish to pypi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,37 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+on: [release]
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pypa/build
+        run: python -m pip install setuptools build wheel --user
+
+      - name: Build a binary wheel
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish any distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
+
+      - name: Publish tagged distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 *.egg-info
 .coverage*
 .idea/*
+/dist


### PR DESCRIPTION
# Description

As discussed in discussion item #181:
This adds a GitHub action file to build and publish a source (bdist) and binary (wheel) distribution to PyPI.
On any release, the action will build and publish to the test PyPI repo.
On any tagged release the artifacts will be published to the production PyPI repo.
The /dist directory is added to the .gitignore file.
A prior PR (#187) was submitted, but the changes were too broad.

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [X] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have deleted all non-relevant text in this pull request template.
