### PR TITLE
Use numpy to calculate pearson corr of non NaN matrices

### DIFF
--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -327,8 +327,15 @@ def get_pairwise_correlation(population_df, method="pearson"):
     # Check that the input method is supported
     method = check_correlation_method(method)
 
-    # Get a symmetrical correlation matrix
-    data_cor_df = population_df.corr(method=method)
+    # Get a symmetrical correlation matrix. Use numpy for non NaN/Inf matrices.
+    has_nan = np.any(np.isnan(population_df.values))
+    has_inf = np.any(np.isinf(population_df.values))
+    if method == "pearson" and not (has_nan or has_inf):
+        pop_names = population_df.columns
+        data_cor_df = np.corrcoef(population_df.transpose())
+        data_cor_df = pd.DataFrame(data_cor_df, index=pop_names, columns=pop_names)
+    else:
+        data_cor_df = population_df.corr(method=method)
 
     # Create a copy of the dataframe to generate upper triangle of zeros
     data_cor_natri_df = data_cor_df.copy()

--- a/pycytominer/tests/test_cyto_utils/test_util.py
+++ b/pycytominer/tests/test_cyto_utils/test_util.py
@@ -1,5 +1,4 @@
 import os
-import random
 import pytest
 import tempfile
 import warnings
@@ -133,23 +132,6 @@ def test_check_consensus_operation_method():
     assert "not supported, select one of" in str(nomethod.value)
 
 
-def test_get_pairwise_correlation():
-    data_df = pd.concat(
-        [
-            pd.DataFrame({"x": [1, 3, 8], "y": [5, 3, 1]}),
-            pd.DataFrame({"x": [1, 3, 5], "y": [8, 3, 1]}),
-        ]
-    ).reset_index(drop=True)
-
-    cor_df, pair_df = get_pairwise_correlation(data_df, method="pearson")
-
-    pd.testing.assert_frame_equal(cor_df, data_df.corr(method="pearson"))
-
-    expected_result = -0.8
-    x_y_cor = pair_df.query("correlation != 0").round(1).correlation.values[0]
-    assert x_y_cor == expected_result
-
-
 def test_check_fields_of_view():
     data_fields_of_view = [1, 3, 4, 5]
 
@@ -263,3 +245,61 @@ def test_extract_image_features():
     pd.testing.assert_frame_equal(
         expected_result.sort_index(axis=1), result.sort_index(axis=1)
     )
+
+
+def _assert_pairwise_corr_helper(data_df, expected_result):
+    '''Assert `get_pairwise_correlation` and `pd.DataFrame.corr` get the same
+    output. It also checks if the first correlation value match the `expected_result`.'''
+    cor_df, pair_df = get_pairwise_correlation(data_df, method="pearson")
+
+    pd.testing.assert_frame_equal(cor_df, data_df.corr(method="pearson"))
+
+    x_y_cor = pair_df.query("correlation != 0").round(1).correlation.values[0]
+    assert x_y_cor == expected_result
+
+
+def test_get_pairwise_correlation():
+    data_df = pd.concat(
+        [
+            pd.DataFrame({"x": [1, 3, 8], "y": [5, 3, 1]}),
+            pd.DataFrame({"x": [1, 3, 5], "y": [8, 3, 1]}),
+        ]
+    ).reset_index(drop=True)
+    expected_result = -0.8
+    _assert_pairwise_corr_helper(data_df, expected_result)
+
+
+def test_pairwise_corr_with_nan():
+    data_df = pd.concat(
+        [
+            pd.DataFrame({"x": [1, 3, 8, 3], "y": [5, 3, 1, None]}),
+            pd.DataFrame({"x": [1, 3, 5, None], "y": [8, 3, 1, 3]}),
+        ]
+    ).reset_index(drop=True)
+
+    expected_result = -0.8
+    _assert_pairwise_corr_helper(data_df, expected_result)
+
+
+def test_pairwise_corr_with_inf():
+    data_df = pd.concat(
+        [
+            pd.DataFrame({"x": [1, 3, 8, 3], "y": [5, 3, 1, float("inf")]}),
+            pd.DataFrame({"x": [1, 3, 5, float("inf")], "y": [8, 3, 1, 3]}),
+        ]
+    ).reset_index(drop=True)
+
+    expected_result = -0.8
+    _assert_pairwise_corr_helper(data_df, expected_result)
+
+
+def test_pairwise_corr_with_inf_and_nan():
+    data_df = pd.concat(
+        [
+            pd.DataFrame({"x": [1, 3, 8, 3], "y": [5, 3, 1, None]}),
+            pd.DataFrame({"x": [1, 3, 5, float("inf")], "y": [8, 3, 1, 3]}),
+        ]
+    ).reset_index(drop=True)
+
+    expected_result = -0.8
+    _assert_pairwise_corr_helper(data_df, expected_result)


### PR DESCRIPTION
# Description

Use `numpy` to calculate pearson correlation in the `transform` module when the input matrix does not have any `NaN` values.

What motivated you to make this change?

`pd.corr` iteratively calculates the correlation while check for `NaN`. This approach prevents vectorized optimizations and makes the computation slow.

If the matrix does not have any `NaN`, then `numpy.corrcoef` will get the same result. Some tests in [stackoverflow](https://stackoverflow.com/a/51654268), report up to 100x speed w.r.t. `pd.corr`.

## What is the nature of your change?

- [x] Enhancement (adds functionality).

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have deleted all non-relevant text in this pull request template.
