### PR TITLE
Fix #192 warnings for scipy mad func and other deprecated params

### DIFF
--- a/pycytominer/cyto_utils/util.py
+++ b/pycytominer/cyto_utils/util.py
@@ -349,7 +349,7 @@ def get_pairwise_correlation(population_df, method="pearson"):
 
     # Replace upper triangle in correlation matrix with NaN
     data_cor_natri_df = data_cor_natri_df.where(
-        np.tril(np.ones(data_cor_natri_df.shape), k=-1).astype(np.bool)
+        np.tril(np.ones(data_cor_natri_df.shape), k=-1).astype(bool)
     )
 
     # Acquire pairwise correlations in a long format

--- a/pycytominer/operations/noise_removal.py
+++ b/pycytominer/operations/noise_removal.py
@@ -71,7 +71,7 @@ def noise_removal(
     population_df = population_df.assign(group_id=group_info)
 
     # Get the standard deviations of features within each group
-    stdev_means_df = population_df.groupby("group_id").apply(lambda x: np.std(x)).mean()
+    stdev_means_df = population_df.groupby("group_id").std(ddof=0).mean()
 
     # Identify noisy features with a greater mean stdev within perturbation group than the threshold
     to_remove = stdev_means_df[

--- a/pycytominer/operations/transform.py
+++ b/pycytominer/operations/transform.py
@@ -169,6 +169,8 @@ class RobustMAD(BaseEstimator, TransformerMixin):
         """
         # Get the mean of the features (columns) and center if specified
         self.median = X.median()
+        # The scale param is required to preserve previous behavior. More info at:
+        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.median_absolute_deviation.html#scipy.stats.median_absolute_deviation
         self.mad = pd.Series(
             median_abs_deviation(X, nan_policy="omit", scale=1/1.4826), index=self.median.index
         )

--- a/pycytominer/operations/transform.py
+++ b/pycytominer/operations/transform.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 import pandas as pd
 from scipy.linalg import eigh
-from scipy.stats import median_absolute_deviation
+from scipy.stats import median_abs_deviation
 from sklearn.base import BaseEstimator, TransformerMixin
 
 
@@ -170,7 +170,7 @@ class RobustMAD(BaseEstimator, TransformerMixin):
         # Get the mean of the features (columns) and center if specified
         self.median = X.median()
         self.mad = pd.Series(
-            median_absolute_deviation(X, nan_policy="omit"), index=self.median.index
+            median_abs_deviation(X, nan_policy="omit", scale=1/1.4826), index=self.median.index
         )
         return self
 

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -4,6 +4,7 @@ import pytest
 import tempfile
 import pandas as pd
 from sqlalchemy import create_engine
+import pytest
 
 from pycytominer import aggregate, normalize
 from pycytominer.cyto_utils.cells import SingleCells, _sqlite_strata_conditions
@@ -135,12 +136,15 @@ ap_subsample = SingleCells(
     subsample_n=2,
     subsampling_random_state=123,
 )
-ap_new = SingleCells(
-    sql_file=new_file,
-    load_image_data=False,
-    compartments=new_compartments,
-    compartment_linking_cols=new_linking_cols,
-)
+
+# Warning expected for compartment "new" because is not in default compartment list.
+with pytest.warns(UserWarning, match='Non-canonical compartment detected: new'):
+    ap_new = SingleCells(
+        sql_file=new_file,
+        load_image_data=False,
+        compartments=new_compartments,
+        compartment_linking_cols=new_linking_cols,
+    )
 
 ap_image_all_features = SingleCells(
     sql_file=image_file,

--- a/pycytominer/tests/test_cyto_utils/test_modz.py
+++ b/pycytominer/tests/test_cyto_utils/test_modz.py
@@ -46,7 +46,7 @@ def test_modz_base():
     consensus_df = modz_base(data_df, min_weight=1, precision=precision)
     expected_result = data_df.mean().round(precision)
     pd.testing.assert_series_equal(
-        expected_result, consensus_df, check_less_precise=True
+        expected_result, consensus_df, check_exact=False, atol=1e-3
     )
 
 
@@ -69,7 +69,7 @@ def test_modz():
     expected_result = data_replicate_df.groupby(replicate_columns).mean().round(4)
     expected_result.index.name = replicate_columns
     pd.testing.assert_frame_equal(
-        expected_result.reset_index(), consensus_df, check_less_precise=True
+        expected_result.reset_index(), consensus_df, check_exact=False, atol=1e-3
     )
 
 
@@ -116,7 +116,7 @@ def test_modz_multiple_columns():
     expected_result = data_replicate_multi_df.groupby(replicate_columns).mean().round(4)
 
     pd.testing.assert_frame_equal(
-        expected_result.reset_index(), consensus_df, check_less_precise=True
+        expected_result.reset_index(), consensus_df, check_exact=False, atol=1e-3
     )
 
 
@@ -146,7 +146,7 @@ def test_modz_multiple_columns_one_metadata_column():
     expected_result = data_replicate_multi_df.groupby(replicate_columns).mean().round(4)
     expected_result.index.name = replicate_columns
     pd.testing.assert_frame_equal(
-        expected_result.reset_index(), consensus_df, check_less_precise=True
+        expected_result.reset_index(), consensus_df, check_exact=False, atol=1e-3
     )
 
 

--- a/pycytominer/tests/test_cyto_utils/test_output.py
+++ b/pycytominer/tests/test_cyto_utils/test_output.py
@@ -55,7 +55,7 @@ def test_compress():
     result = pd.read_csv(output_filename)
 
     pd.testing.assert_frame_equal(
-        result, data_df, check_names=False, check_less_precise=1
+        result, data_df, check_names=False, check_exact=False, atol=1e-3
     )
 
 
@@ -72,7 +72,7 @@ def test_compress_tsv():
 
     result = pd.read_csv(output_filename, sep="\t")
     pd.testing.assert_frame_equal(
-        result, data_df, check_names=False, check_less_precise=1
+        result, data_df, check_names=False, check_exact=False, atol=1e-3
     )
 
 
@@ -88,7 +88,7 @@ def test_output_none():
 
     result = pd.read_csv(output_filename)
     pd.testing.assert_frame_equal(
-        result, data_df, check_names=False, check_less_precise=1
+        result, data_df, check_names=False, check_exact=False, atol=1e-3
     )
 
 

--- a/pycytominer/tests/test_operations/test_transform.py
+++ b/pycytominer/tests/test_operations/test_transform.py
@@ -3,7 +3,7 @@ import random
 import pytest
 import numpy as np
 import pandas as pd
-from scipy.stats import median_absolute_deviation
+from scipy.stats import median_abs_deviation
 from pycytominer.operations.transform import Spherize, RobustMAD
 
 random.seed(123)
@@ -83,7 +83,7 @@ def test_robust_mad():
     assert int(result) == expected_result
 
     # Check a median absolute deviation equal to the number of columns
-    result = median_absolute_deviation(transform_df).sum()
+    result = median_abs_deviation(transform_df, scale=1/1.4826).sum()
     expected_result = data_df.shape[1]
 
     assert int(result) == expected_result


### PR DESCRIPTION
# Description

Change deprecated methods from external libraries.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).

# Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have deleted all non-relevant text in this pull request template.
