### PR TITLE
SQLite Utils: clean_like_nulls and More!

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   build:

--- a/pycytominer/cyto_utils/__init__.py
+++ b/pycytominer/cyto_utils/__init__.py
@@ -37,7 +37,7 @@ from .cp_image_features import (
 from .sqlite import (
     clean_like_nulls,
     collect_columns,
-    contains_conflicting_aff_strg_class,
+    contains_conflicting_aff_storage_class,
     contains_str_like_null,
     engine_from_str,
     update_columns_to_nullable,

--- a/pycytominer/cyto_utils/__init__.py
+++ b/pycytominer/cyto_utils/__init__.py
@@ -34,3 +34,12 @@ from .cp_image_features import (
     aggregate_fields_count,
     aggregate_image_features,
 )
+from .sqlite import (
+    clean_like_nulls,
+    collect_columns,
+    contains_conflicting_aff_strg_class,
+    contains_str_like_null,
+    engine_from_str,
+    update_columns_to_nullable,
+    update_values_like_null_to_null,
+)

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -16,6 +16,7 @@ from pycytominer.cyto_utils import (
     extract_image_features,
     aggregate_fields_count,
     aggregate_image_features,
+    engine_from_str,
 )
 
 default_compartments = get_default_compartments()
@@ -148,7 +149,7 @@ class SingleCells(object):
             self.set_subsample_n(self.subsample_n)
 
         # Connect to sqlite engine
-        self.engine = create_engine(self.sql_file)
+        self.engine = engine_from_str(self.sql_file)
         self.conn = self.engine.connect()
 
         # Throw an error if both subsample_frac and subsample_n is set

--- a/pycytominer/cyto_utils/sqlite.py
+++ b/pycytominer/cyto_utils/sqlite.py
@@ -401,9 +401,13 @@ def update_columns_to_nullable(
             # enable schema writes
             cursor.execute("PRAGMA writable_schema=ON")
 
-            # prepare update statement which will perform the table sql update
+            # Prepare update statement which will perform the table sql update.
+            # Here we use table sqlite_master as a reference instead of sqlite_schema
+            # to avoid possible issues with os/image sqlite version differences.
+            # See the following for more information:
+            # https://sqlite.org/schematab.html#alternative_names
             sql_stmt = """
-            UPDATE sqlite_schema SET sql = :modified_sql
+            UPDATE sqlite_master SET sql = :modified_sql
             WHERE type = 'table' AND UPPER(name) = UPPER(:table_name);
             """
             for name, modified_sql in table_sql_mod.items():

--- a/pycytominer/cyto_utils/sqlite.py
+++ b/pycytominer/cyto_utils/sqlite.py
@@ -1,0 +1,162 @@
+"""
+Pycytominer SQLite utilities
+"""
+
+import logging
+from typing import Optional, Union
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine.base import Engine
+
+# pylint: disable=consider-using-f-string
+
+logger = logging.getLogger(__name__)
+
+# A reference dictionary for SQLite affinity and storage class types
+# See more here: https://www.sqlite.org/datatype3.html#affinity_name_examples
+SQLITE_AFF_REF = {
+    "INTEGER": [
+        "INT",
+        "INTEGER",
+        "TINYINT",
+        "SMALLINT",
+        "MEDIUMINT",
+        "BIGINT",
+        "UNSIGNED BIG INT",
+        "INT2",
+        "INT8",
+    ],
+    "TEXT": [
+        "CHARACTER",
+        "VARCHAR",
+        "VARYING CHARACTER",
+        "NCHAR",
+        "NATIVE CHARACTER",
+        "NVARCHAR",
+        "TEXT",
+        "CLOB",
+    ],
+    "BLOB": ["BLOB"],
+    "REAL": [
+        "REAL",
+        "DOUBLE",
+        "DOUBLE PRECISION",
+        "FLOAT",
+    ],
+    "NUMERIC": [
+        "NUMERIC",
+        "DECIMAL",
+        "BOOLEAN",
+        "DATE",
+        "DATETIME",
+    ],
+}
+
+
+def contains_conflicting_aff_strg_class(
+    sql_engine: Union[str, Engine],
+    table_name: Optional[str] = None,
+    column_name: Optional[str] = None,
+) -> bool:
+    """
+    Detect conflicting column affinity vs data storage class for
+    entire SQLite database, a specific table, or a specific column
+    within a specific table. See the following for more details on
+    affinity vs storage class typing within SQLite:
+    https://www.sqlite.org/datatype3.html
+
+    Parameters
+    ----------
+    sql_engine: str | sqlalchemy.engine.base.Engine
+        filename of the SQLite database or existing sqlalchemy engine
+    table_name: str
+        optional specific table name to check within database
+    column_name: str
+        optional specific column name to check within database
+
+    Returns
+    -------
+    bool
+        Returns True if conflicting storage class values were detected
+        in database provided, else returns False.
+    """
+
+    logger.info(
+        (
+            "Determining if SQLite database contains conflicting column ",
+            "affinity vs storage class values.",
+        )
+    )
+
+    # check the type of sql_engine passed and create engine if we have a str
+    if isinstance(sql_engine, str):
+        engine = create_engine(f"sqlite:///{sql_engine}")
+    else:
+        engine = sql_engine
+
+        with engine.connect() as connection:
+            if table_name is None:
+                # if no table name is provided, we assume all tables must be scanned
+                tables = connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table';"
+                ).fetchall()
+            else:
+                # otherwise we will focus on just the table name provided
+                tables = [(table_name,)]
+
+            for table in tables:
+                if column_name is None:
+                    # if no column name is specified we will focus on all columns within the table
+                    sql_stmt = "SELECT name, type FROM pragma_table_info(:table_name);"
+                else:
+                    # otherwise we will focus on only the column name provided
+                    sql_stmt = """
+                    SELECT name, type FROM pragma_table_info(:table_name) WHERE name = :col_name;
+                    """
+
+                cols = connection.execute(
+                    sql_stmt,
+                    {"table_name": str(table[0]), "col_name": str(column_name)},
+                ).fetchall()
+
+                for col in cols:
+                    # the sql below seeks to efficiently detect existence of values which
+                    # do not match the column affinity type (for ex. a string in an integer column).
+                    sql_stmt = """
+                    SELECT
+                        EXISTS(
+                            SELECT 1 FROM {table_name} 
+                            WHERE TYPEOF({col_name}) NOT IN ({col_types})
+                        );
+                    """
+                    # join formatted string for use with sql query in {col_types} var
+                    col_types = ",".join(
+                        ["'{}'".format(x.lower()) for x in SQLITE_AFF_REF[col[1]]]
+                    )
+
+                    # there are challenges with using sqlalchemy vars in the same manner as above
+                    # so we use format here along with nosec
+                    result = connection.execute(
+                        sql_stmt.format(
+                            table_name=table[0],
+                            col_name=col[0],
+                            col_types=col_types,
+                        )
+                    ).fetchall()[0][
+                        0
+                    ]  # nosec
+                    if result > 0:
+                        # if our result is greater than 0 it means values with conflicting storage
+                        # class existed within the focus column and as a result, we return False
+                        logger.warning(
+                            "Discovered conflicting %s column %s affinity type and storage class.",
+                            table[0],
+                            col[0],
+                        )
+                        return True
+
+    # return false if we did not find conflicting affinity vs storage class values
+    logger.info(
+        "Found no conflicting affinity vs storage class data within provided database."
+    )
+    return False

--- a/pycytominer/cyto_utils/sqlite.py
+++ b/pycytominer/cyto_utils/sqlite.py
@@ -141,7 +141,7 @@ def collect_columns(
 
             if column_name is not None:
                 # otherwise we will focus on only the column name provided
-                sql_stmt += " WHERE name = :col_name;"
+                sql_stmt = f"{sql_stmt} WHERE name = :col_name;"
 
             # append to column list the results
             column_list += connection.execute(
@@ -152,7 +152,7 @@ def collect_columns(
     return column_list
 
 
-def contains_conflicting_aff_strg_class(
+def contains_conflicting_aff_storage_class(
     sql_engine: Union[str, Engine],
     table_name: Optional[str] = None,
     column_name: Optional[str] = None,

--- a/pycytominer/cyto_utils/sqlite.py
+++ b/pycytominer/cyto_utils/sqlite.py
@@ -315,7 +315,7 @@ def contains_str_like_null(
 
 def update_columns_to_nullable(
     sql_engine: Union[str, Engine],
-    dest_path: str = None,
+    dest_path: Optional[str] = None,
     table_name: Optional[str] = None,
     inplace: bool = True,
 ) -> Engine:
@@ -508,7 +508,7 @@ def update_values_like_null_to_null(
 
 def clean_like_nulls(
     sql_engine: Union[str, Engine],
-    dest_path: str = None,
+    dest_path: Optional[str] = None,
     table_name: Optional[str] = None,
     column_name: Optional[str] = None,
     inplace: bool = True,

--- a/pycytominer/cyto_utils/sqlite.py
+++ b/pycytominer/cyto_utils/sqlite.py
@@ -3,6 +3,8 @@ Pycytominer SQLite utilities
 """
 
 import logging
+import os
+import sqlite3
 from typing import Optional, Union
 
 from sqlalchemy import create_engine
@@ -53,6 +55,33 @@ SQLITE_AFF_REF = {
 }
 
 
+def engine_from_str(sql_engine: Union[str, Engine]) -> Engine:
+    """
+    Helper function to create engine from a string or return the engine
+    if it's already been created.
+
+    Parameters
+    ----------
+    sql_engine: str | sqlalchemy.engine.base.Engine
+        filename of the SQLite database or existing sqlalchemy engine
+    Returns
+    -------
+    sqlalchemy.engine.base.Engine
+        A SQLAlchemy engine
+    """
+
+    # check the type of sql_engine passed and create engine if we have a str
+    if isinstance(sql_engine, str):
+        # if we don't already have the sqlite filestring, add it
+        if "sqlite:///" not in sql_engine:
+            sql_engine = "sqlite:///{}".format(sql_engine)
+        engine = create_engine(sql_engine)
+    else:
+        engine = sql_engine
+
+    return engine
+
+
 def contains_conflicting_aff_strg_class(
     sql_engine: Union[str, Engine],
     table_name: Optional[str] = None,
@@ -88,75 +117,212 @@ def contains_conflicting_aff_strg_class(
         )
     )
 
-    # check the type of sql_engine passed and create engine if we have a str
-    if isinstance(sql_engine, str):
-        engine = create_engine(f"sqlite:///{sql_engine}")
-    else:
-        engine = sql_engine
+    engine = engine_from_str(sql_engine)
 
-        with engine.connect() as connection:
-            if table_name is None:
-                # if no table name is provided, we assume all tables must be scanned
-                tables = connection.execute(
-                    "SELECT name FROM sqlite_master WHERE type = 'table';"
-                ).fetchall()
+    with engine.connect() as connection:
+        if table_name is None:
+            # if no table name is provided, we assume all tables must be scanned
+            tables = connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table';"
+            ).fetchall()
+        else:
+            # otherwise we will focus on just the table name provided
+            tables = [(table_name,)]
+
+        for table in tables:
+            if column_name is None:
+                # if no column name is specified we will focus on all columns within the table
+                sql_stmt = "SELECT name, type FROM pragma_table_info(:table_name);"
             else:
-                # otherwise we will focus on just the table name provided
-                tables = [(table_name,)]
+                # otherwise we will focus on only the column name provided
+                sql_stmt = """
+                SELECT name, type FROM pragma_table_info(:table_name) WHERE name = :col_name;
+                """
 
-            for table in tables:
-                if column_name is None:
-                    # if no column name is specified we will focus on all columns within the table
-                    sql_stmt = "SELECT name, type FROM pragma_table_info(:table_name);"
-                else:
-                    # otherwise we will focus on only the column name provided
-                    sql_stmt = """
-                    SELECT name, type FROM pragma_table_info(:table_name) WHERE name = :col_name;
-                    """
+            cols = connection.execute(
+                sql_stmt,
+                {"table_name": str(table[0]), "col_name": str(column_name)},
+            ).fetchall()
 
-                cols = connection.execute(
-                    sql_stmt,
-                    {"table_name": str(table[0]), "col_name": str(column_name)},
-                ).fetchall()
+            for col in cols:
+                # the sql below seeks to efficiently detect existence of values which
+                # do not match the column affinity type (for ex. a string in an integer column).
+                sql_stmt = """
+                SELECT
+                    EXISTS(
+                        SELECT 1 FROM {table_name} 
+                        WHERE TYPEOF({col_name}) NOT IN ({col_types})
+                    );
+                """
+                # join formatted string for use with sql query in {col_types} var
+                col_types = ",".join(
+                    ["'{}'".format(x.lower()) for x in SQLITE_AFF_REF[col[1]]]
+                )
 
-                for col in cols:
-                    # the sql below seeks to efficiently detect existence of values which
-                    # do not match the column affinity type (for ex. a string in an integer column).
-                    sql_stmt = """
-                    SELECT
-                        EXISTS(
-                            SELECT 1 FROM {table_name} 
-                            WHERE TYPEOF({col_name}) NOT IN ({col_types})
-                        );
-                    """
-                    # join formatted string for use with sql query in {col_types} var
-                    col_types = ",".join(
-                        ["'{}'".format(x.lower()) for x in SQLITE_AFF_REF[col[1]]]
+                # there are challenges with using sqlalchemy vars in the same manner as above
+                # so we use format here along with nosec
+                result = connection.execute(
+                    sql_stmt.format(
+                        table_name=table[0],
+                        col_name=col[0],
+                        col_types=col_types,
                     )
-
-                    # there are challenges with using sqlalchemy vars in the same manner as above
-                    # so we use format here along with nosec
-                    result = connection.execute(
-                        sql_stmt.format(
-                            table_name=table[0],
-                            col_name=col[0],
-                            col_types=col_types,
-                        )
-                    ).fetchall()[0][
-                        0
-                    ]  # nosec
-                    if result > 0:
-                        # if our result is greater than 0 it means values with conflicting storage
-                        # class existed within the focus column and as a result, we return False
-                        logger.warning(
-                            "Discovered conflicting %s column %s affinity type and storage class.",
-                            table[0],
-                            col[0],
-                        )
-                        return True
+                ).fetchall()[0][
+                    0
+                ]  # nosec
+                if result > 0:
+                    # if our result is greater than 0 it means values with conflicting storage
+                    # class existed within the focus column and as a result, we return False
+                    logger.warning(
+                        "Discovered conflicting %s column %s affinity type and storage class.",
+                        table[0],
+                        col[0],
+                    )
+                    return True
 
     # return false if we did not find conflicting affinity vs storage class values
     logger.info(
         "Found no conflicting affinity vs storage class data within provided database."
     )
     return False
+
+
+def update_columns_to_nullable(
+    sql_engine: Union[str, Engine],
+    dest_path: str = None,
+    table_name: Optional[str] = None,
+    inplace: bool = False,
+) -> Engine:
+    """
+    Update SQLite database columns to nullable where appropriate.
+    Use a backup database to avoid data corruption issues and
+    roughly follow 9-step procedure outlined by SQLite docs here:
+    https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes
+
+    Special notes:
+    - We take advantage of Python >= 3.7 sqlite3 api backup capabilities
+    to keep to a standard implementation for backup portion of this work.
+
+    Parameters
+    ----------
+    sql_engine: str | sqlalchemy.engine.base.Engine
+        filename of the SQLite database or existing sqlalchemy engine
+    dest_path: str
+        the destination of the updated database with nullable columns.
+    table_name: str
+        optional specific table name to update within database
+    inplace: bool
+        whether to replace the source sql database, by default set to false.
+
+    Returns
+    -------
+    sqlalchemy.engine.base.Engine
+        A SQLAlchemy engine for the changed database
+    """
+
+    logger.info("Updating database columns to nullable for provided database.")
+
+    # setup a source database connection
+    if isinstance(sql_engine, Engine):
+        # gather sqlalchemy engine url replacing incompatible strings
+        src_sql_url = str(sql_engine.url).replace("sqlite:///", "")
+    else:
+        src_sql_url = sql_engine
+
+    source_engine = sqlite3.connect(src_sql_url)
+
+    # add a default destination path which is separate from our source
+    if dest_path is None:
+        dest_path = src_sql_url + "_column_update"
+
+    # setup a destination database connection
+    dest_engine = sqlite3.connect(dest_path)
+
+    # create backup of database using sqlite3 api
+    source_engine.backup(dest_engine)
+
+    # gather schema_version for later update
+    schema_version = dest_engine.execute("PRAGMA schema_version;").fetchall()[0][0]
+
+    # gather existing table(s) sql later update
+    if table_name is not None:
+        # if we have a table name provided, target only that table for the modifications
+        sql_stmt = (
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE type = 'table' and UPPER(name) = UPPER(:table_name)"
+        )
+    else:
+        # else we target all tables within the database
+        sql_stmt = "SELECT name, sql FROM sqlite_master WHERE type = 'table';"
+
+    table_sql_fetch = dest_engine.execute(
+        sql_stmt, {"table_name": table_name}
+    ).fetchall()
+
+    # prepare table sql with removed not null columns
+    table_sql_mod = {
+        table[0]: table[1].replace("NOT NULL", "") for table in table_sql_fetch
+    }
+
+    if len(table_sql_mod) > 0:
+        # check that we have sql to modify
+
+        # disallow autocommit and create cursor for transaction
+        dest_engine.isolation_level = None
+        cursor = dest_engine.cursor()
+        try:
+            # begin transaction
+            cursor.execute("begin")
+
+            # enable schema writes
+            cursor.execute("PRAGMA writable_schema=ON")
+
+            # prepare update statement which will perform the table sql update
+            sql_stmt = """
+            UPDATE sqlite_schema SET sql = :modified_sql 
+            WHERE type = 'table' AND UPPER(name) = UPPER(:table_name);
+            """
+            for name, modified_sql in table_sql_mod.items():
+                cursor.execute(
+                    sql_stmt, {"table_name": name, "modified_sql": modified_sql}
+                )
+            # increment the schema version to track the change
+            cursor.execute(
+                "PRAGMA schema_version={new_version};".format(
+                    new_version=schema_version + 1
+                ),
+            )
+
+            # disable schema writes
+            cursor.execute("PRAGMA writable_schema=OFF")
+
+            # check the integrity of the database as advised by SQLite docs
+            if cursor.execute("PRAGMA integrity_check").fetchall()[0][0] != "ok":
+                raise sqlite3.IntegrityError(
+                    "Detected integrity issue within database after modifications."
+                )
+
+            # commit the changes
+            cursor.execute("commit;")
+
+        except sqlite3.Error as err:
+            logger.error(err)
+            cursor.execute("rollback;")
+
+    if inplace:
+        # backup our destination into the source engine, overwriting our original
+        dest_engine.backup(source_engine)
+
+    # close our connections
+    source_engine.close()
+    dest_engine.close()
+
+    if inplace:
+        # remove working backup
+        os.remove(dest_path.replace("sqlite:///", ""))
+
+        # return source database
+        return engine_from_str(src_sql_url)
+
+    # return copied and modified destination database
+    return engine_from_str(dest_path)

--- a/pycytominer/cyto_utils/sqlite.py
+++ b/pycytominer/cyto_utils/sqlite.py
@@ -454,7 +454,7 @@ def update_columns_to_nullable(
     return engine_from_str(dest_path)
 
 
-def update_columns_like_null_to_null(
+def update_values_like_null_to_null(
     sql_engine: Union[str, Engine],
     table_name: Optional[str] = None,
     column_name: Optional[str] = None,
@@ -546,7 +546,7 @@ def clean_like_nulls(
             )
 
         # update the like nulls to actual null
-        sql_engine = update_columns_like_null_to_null(
+        sql_engine = update_values_like_null_to_null(
             sql_engine, table_name, column_name
         )
 

--- a/pycytominer/cyto_utils/sqlite.py
+++ b/pycytominer/cyto_utils/sqlite.py
@@ -476,7 +476,7 @@ def update_values_like_null_to_null(
     sqlalchemy.engine.base.Engine
         A SQLAlchemy engine for the changed database
     """
-    logger.info("Updating columns with str 'nan' to NULL values.")
+    logger.info("Updating column values with str 'nan' to NULL values.")
 
     # create an engine
     engine = engine_from_str(sql_engine)
@@ -531,6 +531,13 @@ def clean_like_nulls(
     sqlalchemy.engine.base.Engine
         A SQLAlchemy engine for the database
     """
+
+    logger.info(
+        (
+            "Updating column values with str 'nan' to NULL values, "
+            "making changes where necessary."
+        )
+    )
 
     # if we detect that there are strings like nulls in the database
     if contains_str_like_null(sql_engine, table_name, column_name):

--- a/pycytominer/cyto_utils/sqlite.py
+++ b/pycytominer/cyto_utils/sqlite.py
@@ -91,6 +91,21 @@ def collect_columns(
     Collect a list of columns from the given engine's
     database using optional table or column level
     specification.
+
+    Parameters
+    ----------
+    sql_engine: str | sqlalchemy.engine.base.Engine
+        filename of the SQLite database or existing sqlalchemy engine
+    table_name: str
+        optional specific table name to check within database
+    column_name: str
+        optional specific column name to check within database
+
+    Returns
+    -------
+    list
+        Returns list of tuples with values
+        ('table_name', 'column_name', 'column_affinity_type')
     """
 
     # create column list for return result
@@ -360,7 +375,23 @@ def update_columns_nan_to_null(
     table_name: Optional[str] = None,
     column_name: Optional[str] = None,
 ) -> Engine:
+    """
+    Updates column values from 'nan' to NULL where possible.
 
+    Parameters
+    ----------
+    sql_engine: str | sqlalchemy.engine.base.Engine
+        filename of the SQLite database or existing sqlalchemy engine
+    table_name: str
+        optional specific table name to check within database
+    column_name: str
+        optional specific column name to check within database
+
+    Returns
+    -------
+    sqlalchemy.engine.base.Engine
+        A SQLAlchemy engine for the changed database
+    """
     logger.info("Updating columns with str 'nan' to NULL values.")
 
     # create an engine

--- a/pycytominer/tests/test_cyto_utils/test_sqlite.py
+++ b/pycytominer/tests/test_cyto_utils/test_sqlite.py
@@ -29,7 +29,7 @@ def database_engine_for_testing() -> Engine:
     tmpdir = tempfile.gettempdir()
 
     # create a temporary sqlite connection
-    sql_path = "sqlite:///{}/test.sqlite".format(tmpdir)
+    sql_path = "sqlite:///{}/test_sqlite.sqlite".format(tmpdir)
     engine = create_engine(sql_path)
 
     # statements for creating database with simple structure

--- a/pycytominer/tests/test_cyto_utils/test_sqlite.py
+++ b/pycytominer/tests/test_cyto_utils/test_sqlite.py
@@ -10,7 +10,7 @@ from pycytominer.cyto_utils.sqlite import (
     LIKE_NULLS,
     clean_like_nulls,
     collect_columns,
-    contains_conflicting_aff_strg_class,
+    contains_conflicting_aff_storage_class,
     contains_str_like_null,
     engine_from_str,
     update_columns_to_nullable,
@@ -119,26 +119,26 @@ def test_collect_columns(database_engine_for_testing):
     ) == [("tbl_b", "col_integer", "INTEGER", 0)]
 
 
-def test_contains_conflicting_aff_strg_class(database_engine_for_testing):
+def test_contains_conflicting_aff_storage_class(database_engine_for_testing):
     """
-    Testing contains_conflicting_aff_strg_class
+    Testing contains_conflicting_aff_storage_class
     """
 
     # test string-based sql_path and empty database (no schema should mean no conflict)
-    assert contains_conflicting_aff_strg_class(sql_engine=":memory:") is False
+    assert contains_conflicting_aff_storage_class(sql_engine=":memory:") is False
 
     # test non-conflicting database
-    assert contains_conflicting_aff_strg_class(database_engine_for_testing) is False
+    assert contains_conflicting_aff_storage_class(database_engine_for_testing) is False
     # test non-conlicting database single table
     assert (
-        contains_conflicting_aff_strg_class(
+        contains_conflicting_aff_storage_class(
             database_engine_for_testing, table_name="tbl_a"
         )
         is False
     )
     # test non-conlicting database single table and single column
     assert (
-        contains_conflicting_aff_strg_class(
+        contains_conflicting_aff_storage_class(
             database_engine_for_testing, table_name="tbl_a", column_name="col_integer"
         )
         is False
@@ -154,31 +154,31 @@ def test_contains_conflicting_aff_strg_class(database_engine_for_testing):
         )
 
     # test conflicting database
-    assert contains_conflicting_aff_strg_class(database_engine_for_testing) is True
+    assert contains_conflicting_aff_storage_class(database_engine_for_testing) is True
     # test conflicting database single table, conflicting table
     assert (
-        contains_conflicting_aff_strg_class(
+        contains_conflicting_aff_storage_class(
             database_engine_for_testing, table_name="tbl_a"
         )
         is True
     )
     # test conflicting database single table, non-conflicting table
     assert (
-        contains_conflicting_aff_strg_class(
+        contains_conflicting_aff_storage_class(
             database_engine_for_testing, table_name="tbl_b"
         )
         is False
     )
     # test conflicting database single table and single conflicting column
     assert (
-        contains_conflicting_aff_strg_class(
+        contains_conflicting_aff_storage_class(
             database_engine_for_testing, table_name="tbl_a", column_name="col_integer"
         )
         is True
     )
     # test conflicting database single table and single non-conflicting column
     assert (
-        contains_conflicting_aff_strg_class(
+        contains_conflicting_aff_storage_class(
             database_engine_for_testing, table_name="tbl_a", column_name="col_text"
         )
         is False

--- a/pycytominer/tests/test_cyto_utils/test_sqlite.py
+++ b/pycytominer/tests/test_cyto_utils/test_sqlite.py
@@ -1,0 +1,114 @@
+""" Tests for pycytominer.cyto_utils.sqlite """
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.engine.base import Engine
+from pycytominer.cyto_utils.sqlite import contains_conflicting_aff_strg_class
+
+
+@pytest.fixture
+def database_engine_for_testing() -> Engine:
+    """
+    A database engine for testing as a fixture to be passed
+    to other tests within this file.
+    """
+
+    # set our path to an in-memory database and create the engine
+    sql_path = ":memory:"
+    engine = create_engine(f"sqlite:///{sql_path}")
+
+    # statements for creating database with simple structure
+    create_stmts = [
+        """
+    drop table if exists tbl_a;
+    """,
+        """
+    create table tbl_a (
+    col_integer INTEGER
+    ,col_text TEXT
+    ,col_blob BLOB
+    ,col_real REAL
+    );
+    """,
+        """
+    create table tbl_b (
+    col_integer INTEGER
+    ,col_text TEXT
+    ,col_blob BLOB
+    ,col_real REAL
+    );
+    """,
+    ]
+
+    # insert statement with some simple values
+    # note: we use SQLAlchemy's parameters to insert data properly, esp. BLOB
+    insert_stmt_a = """
+    INSERT INTO tbl_a (col_integer, col_text, col_blob, col_real)
+    VALUES (?, ?, ?, ?);
+    """
+    insert_stmt_b = """
+    INSERT INTO tbl_b (col_integer, col_text, col_blob, col_real)
+    VALUES (?, ?, ?, ?);
+    """
+    insert_vals = [1, "sample", b"sample_blob", 0.5]
+
+    with engine.connect() as e:
+        for stmt in create_stmts:
+            e.execute(stmt)
+        e.execute(insert_stmt_a, insert_vals)
+        e.execute(insert_stmt_b, insert_vals)
+
+    return engine
+
+
+def test_contains_conflicting_aff_strg_class(database_engine_for_testing):
+    """
+    Testing contains_conflicting_aff_strg_class
+    """
+
+    # test string-based sql_path and empty database (no schema should mean no conflict)
+    assert contains_conflicting_aff_strg_class(sql_engine=":memory:") == False
+
+    engine = database_engine_for_testing
+
+    # test non-conflicting database
+    assert contains_conflicting_aff_strg_class(engine) == False
+    # test non-conlicting database single table
+    assert contains_conflicting_aff_strg_class(engine, table_name="tbl_a") == False
+    # test non-conlicting database single table and single column
+    assert (
+        contains_conflicting_aff_strg_class(
+            engine, table_name="tbl_a", column_name="col_integer"
+        )
+        == False
+    )
+
+    # add a conflicting row of values for tbl_a
+    with engine.connect() as e:
+        e.execute(
+            """
+        INSERT INTO tbl_a (col_integer, col_text, col_blob, col_real)
+        VALUES ('nan', 'another', 'example', 0.5);
+        """
+        )
+
+    # test conflicting database
+    assert contains_conflicting_aff_strg_class(engine) == True
+    # test conflicting database single table, conflicting table
+    assert contains_conflicting_aff_strg_class(engine, table_name="tbl_a") == True
+    # test conflicting database single table, non-conflicting table
+    assert contains_conflicting_aff_strg_class(engine, table_name="tbl_b") == False
+    # test conflicting database single table and single conflicting column
+    assert (
+        contains_conflicting_aff_strg_class(
+            engine, table_name="tbl_a", column_name="col_integer"
+        )
+        == True
+    )
+    # test conflicting database single table and single non-conflicting column
+    assert (
+        contains_conflicting_aff_strg_class(
+            engine, table_name="tbl_a", column_name="col_text"
+        )
+        == False
+    )

--- a/pycytominer/tests/test_cyto_utils/test_sqlite.py
+++ b/pycytominer/tests/test_cyto_utils/test_sqlite.py
@@ -105,19 +105,19 @@ def test_collect_columns(database_engine_for_testing):
     assert len(collect_columns(database_engine_for_testing)) == 8
 
     # test single database table collected
-    assert len(collect_columns(database_engine_for_testing, table_name="tbl_a")) == 4
+    assert collect_columns(database_engine_for_testing, table_name="tbl_a") == [
+        ("tbl_a", "col_integer", "INTEGER"),
+        ("tbl_a", "col_text", "TEXT"),
+        ("tbl_a", "col_blob", "BLOB"),
+        ("tbl_a", "col_real", "REAL"),
+    ]
 
     # test single column from single table collected
-    assert (
-        len(
-            collect_columns(
-                database_engine_for_testing,
-                table_name="tbl_a",
-                column_name="col_integer",
-            )
-        )
-        == 1
-    )
+    assert collect_columns(
+        database_engine_for_testing,
+        table_name="tbl_b",
+        column_name="col_integer",
+    ) == [("tbl_b", "col_integer", "INTEGER")]
 
 
 def test_contains_conflicting_aff_strg_class(database_engine_for_testing):

--- a/pycytominer/tests/test_cyto_utils/test_sqlite.py
+++ b/pycytominer/tests/test_cyto_utils/test_sqlite.py
@@ -4,14 +4,14 @@ import tempfile
 
 import pytest
 from pycytominer.cyto_utils.sqlite import (
+    LIKE_NULLS,
     clean_like_nulls,
     collect_columns,
     contains_conflicting_aff_strg_class,
     contains_str_like_null,
     engine_from_str,
-    update_columns_like_null_to_null,
     update_columns_to_nullable,
-    LIKE_NULLS,
+    update_values_like_null_to_null,
 )
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
@@ -269,13 +269,13 @@ def test_update_columns_to_nullable(database_engine_for_testing):
     assert updated_engine.url == database_engine_for_testing.url
 
 
-def test_update_columns_like_null_to_null(database_engine_for_testing):
+def test_update_values_like_null_to_null(database_engine_for_testing):
     """
-    Testing update_columns_like_null_to_null
+    Testing update_values_like_null_to_null
     """
 
     # test updating tbl_b
-    updated_engine = update_columns_like_null_to_null(
+    updated_engine = update_values_like_null_to_null(
         sql_engine=database_engine_for_testing
     )
 
@@ -292,7 +292,7 @@ def test_update_columns_like_null_to_null(database_engine_for_testing):
         )
 
     # test updating only tbl_a col_text
-    updated_engine = update_columns_like_null_to_null(
+    updated_engine = update_values_like_null_to_null(
         sql_engine=database_engine_for_testing,
         table_name="tbl_a",
         column_name="col_text",
@@ -306,7 +306,7 @@ def test_update_columns_like_null_to_null(database_engine_for_testing):
     assert updated_engine.execute(sql_stmt).fetchone()[0] == 0
 
     # test updating only tbl_a col_blob
-    updated_engine = update_columns_like_null_to_null(
+    updated_engine = update_values_like_null_to_null(
         sql_engine=database_engine_for_testing,
         table_name="tbl_a",
         column_name="col_blob",
@@ -322,7 +322,7 @@ def test_update_columns_like_null_to_null(database_engine_for_testing):
     # test updating only tbl_a col_integer
     # should raise exception due to not null constraint
     with pytest.raises(IntegrityError):
-        updated_engine = update_columns_like_null_to_null(
+        updated_engine = update_values_like_null_to_null(
             sql_engine=database_engine_for_testing,
             table_name="tbl_a",
             column_name="col_integer",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     packages=find_packages(),
     license=about["__license__"],
     install_requires=["numpy", "pandas", "scikit-learn", "sqlalchemy"],
-    python_requires=">=3.4",
+    python_requires=">=3.7",
     include_package_data=True,
 )


### PR DESCRIPTION
This change adds a new series of utilities under pycytominer/cyto_utils/sqlite.py for detecting the need for and making changes to SQLite databases used by this project. The work seeks to improve performance, especially memory resource challenges as originally cited in #195 and further investigated as part of #198. Minimal logging has been added to the utilities to assist those making use of the functions and also as work towards #5 .

_Special notes:_
- Python >= 3.7 is required due to the use of the [sqlite3.Connection.backup](https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.backup) (a safety measure to avoid database corruption during changes within update_columns_to_nullable).
- Functions within are provided to assist with someone's  ability to investigate SQLite source databases. These are intended to be used optionally within other classes and methods or on their own.

_Open questions:_ 
- Will moving to SQLite `Null` and related `numpy.nan` within subsequent Pandas dataframes on read present any challenges (or other opportunities) for using data elsewhere within this library? Would we need any additional changes as a result?
- Would it be beneficial to add clean_like_nulls as a "pre-step" to functions like `merge_single_cells`?

Thank you for any feedback, suggestions, and thoughts you may have!

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
