### PR TITLE
Add column numbers to DP locations

### DIFF
--- a/pycytominer/cyto_utils/DeepProfiler_processing.py
+++ b/pycytominer/cyto_utils/DeepProfiler_processing.py
@@ -360,15 +360,13 @@ class SingleCellDeepProfiler:
 
         self.deep_data = deep_data
 
-
     def get_single_cells_column(self, output=False, column_num=0):
         # build filenames if they do not already exist
         if not hasattr(self.deep_data, "filenames"):
             self.deep_data.build_filenames()
-        
-        
+
         total_features = np.ndarray(shape=(0, 1280), dtype=np.float32)
-        
+
         for features_path in self.deep_data.filenames:
             print(features_path)
             features = load_npz_features(features_path, metadata=False)
@@ -381,14 +379,13 @@ class SingleCellDeepProfiler:
             # set column numbers of empty dataframe on first iteration
             # if total_features.shape == (0,0):
             #     total_features = np.ndarray(shape=(0,features.shape[1]))
-            
+
             features = features.astype(np.float32)
             total_features = np.concatenate((total_features, features), axis=0)
-        
+
         return total_features
 
-
-    def get_single_cells(self, output=False, location_columns=(0,1)):
+    def get_single_cells(self, output=False, location_columns=(0, 1)):
         """
         Sets up the single_cells attribute or output as a variable. This is a helper function to normalize_deep_single_cells().
         single_cells is a pandas dataframe in the format expected by pycytominer.normalize().
@@ -397,6 +394,8 @@ class SingleCellDeepProfiler:
         -----------
         output : bool
             If true, will output the single cell dataframe instead of setting to self attribute
+        location_columns : tuple
+            (location_center_x column number, location_center_y column number), column numbers for location data. used when loading locations from DP output
         """
         # build filenames if they do not already exist
         if not hasattr(self.deep_data, "filenames"):
@@ -425,7 +424,7 @@ class SingleCellDeepProfiler:
 
     def normalize_deep_single_cells(
         self,
-        location_columns=(0,1),
+        location_columns=(0, 1),
         image_features=False,  # not implemented with DeepProfiler
         meta_features="infer",
         samples="all",
@@ -455,7 +454,7 @@ class SingleCellDeepProfiler:
         print("getting single cells")
         # setup single_cells attribute
         if not hasattr(self, "single_cells"):
-            self.get_single_cells(output=False, location_columns=location_columns)        
+            self.get_single_cells(output=False, location_columns=location_columns)
 
         # extract metadata prior to normalization
         metadata_cols = infer_cp_features(self.single_cells, metadata=True)

--- a/pycytominer/cyto_utils/DeepProfiler_processing.py
+++ b/pycytominer/cyto_utils/DeepProfiler_processing.py
@@ -360,31 +360,6 @@ class SingleCellDeepProfiler:
 
         self.deep_data = deep_data
 
-    def get_single_cells_column(self, output=False, column_num=0):
-        # build filenames if they do not already exist
-        if not hasattr(self.deep_data, "filenames"):
-            self.deep_data.build_filenames()
-
-        total_features = np.ndarray(shape=(0, 1280), dtype=np.float32)
-
-        for features_path in self.deep_data.filenames:
-            print(features_path)
-            features = load_npz_features(features_path, metadata=False)
-            # skip a file if there are no features
-            if len(features.index) == 0:
-                warnings.warn(
-                    f"No features could be found at {features_path}.\nThis program will continue, but be aware that this might induce errors!"
-                )
-                continue
-            # set column numbers of empty dataframe on first iteration
-            # if total_features.shape == (0,0):
-            #     total_features = np.ndarray(shape=(0,features.shape[1]))
-
-            features = features.astype(np.float32)
-            total_features = np.concatenate((total_features, features), axis=0)
-
-        return total_features
-
     def get_single_cells(self, output=False, location_columns=(0, 1)):
         """
         Sets up the single_cells attribute or output as a variable. This is a helper function to normalize_deep_single_cells().

--- a/pycytominer/cyto_utils/DeepProfiler_processing.py
+++ b/pycytominer/cyto_utils/DeepProfiler_processing.py
@@ -360,7 +360,7 @@ class SingleCellDeepProfiler:
 
         self.deep_data = deep_data
 
-    def get_single_cells(self, output=False, location_columns=(0, 1)):
+    def get_single_cells(self, output=False, location_x_col_index = 0, location_y_col_index = 1):
         """
         Sets up the single_cells attribute or output as a variable. This is a helper function to normalize_deep_single_cells().
         single_cells is a pandas dataframe in the format expected by pycytominer.normalize().
@@ -369,8 +369,10 @@ class SingleCellDeepProfiler:
         -----------
         output : bool
             If true, will output the single cell dataframe instead of setting to self attribute
-        location_columns : tuple
-            (location_center_x column number, location_center_y column number), column numbers for location data. used when loading locations from DP output
+        location_x_col_index: int
+            index of the x location column (which column in DP output has X coords)
+        location_y_col_index: int
+            index of the y location column (which column in DP output has Y coords)
         """
         # build filenames if they do not already exist
         if not hasattr(self.deep_data, "filenames"):
@@ -386,7 +388,7 @@ class SingleCellDeepProfiler:
                     f"No features could be found at {features_path}.\nThis program will continue, but be aware that this might induce errors!"
                 )
                 continue
-            locations = load_npz_locations(features_path, location_columns)
+            locations = load_npz_locations(features_path, location_x_col_index, location_y_col_index)
             detailed_df = pd.concat([locations, features], axis=1)
 
             total_df.append(detailed_df)
@@ -399,7 +401,8 @@ class SingleCellDeepProfiler:
 
     def normalize_deep_single_cells(
         self,
-        location_columns=(0, 1),
+        location_x_col_index = 0, 
+        location_y_col_index = 1,
         image_features=False,  # not implemented with DeepProfiler
         meta_features="infer",
         samples="all",
@@ -429,7 +432,7 @@ class SingleCellDeepProfiler:
         print("getting single cells")
         # setup single_cells attribute
         if not hasattr(self, "single_cells"):
-            self.get_single_cells(output=False, location_columns=location_columns)
+            self.get_single_cells(output=False, location_x_col_index=location_x_col_index, location_y_col_index=location_y_col_index)
 
         # extract metadata prior to normalization
         metadata_cols = infer_cp_features(self.single_cells, metadata=True)

--- a/pycytominer/cyto_utils/load.py
+++ b/pycytominer/cyto_utils/load.py
@@ -147,7 +147,7 @@ def load_npz_features(npz_file, fallback_feature_prefix="DP", metadata=True):
     return df
 
 
-def load_npz_locations(npz_file, location_columns=(0, 1)):
+def load_npz_locations(npz_file, location_x_col_index = 0, location_y_col_index = 1):
     """
     Load an npz file storing locations and, sometimes, metadata.
 
@@ -161,8 +161,10 @@ def load_npz_locations(npz_file, location_columns=(0, 1)):
     ----------
     npz_file : str
         file path to the compressed output (typically DeepProfiler output)
-    location_columns : tuple
-        (location_center_x column number, location_center_y column number), column numbers for location data
+    location_x_col_index: int
+        index of the x location column (which column in DP output has X coords)
+    location_y_col_index: int
+        index of the y location column (which column in DP output has Y coords)
 
     Return
     ------
@@ -178,7 +180,7 @@ def load_npz_locations(npz_file, location_columns=(0, 1)):
 
     try:
         df = pd.DataFrame(npz["locations"])
-        df = df[[location_columns[0], location_columns[1]]]
+        df = df[[location_x_col_index, location_y_col_index]]
         df.columns = ["Location_Center_X", "Location_Center_Y"]
         return df
     except:

--- a/pycytominer/cyto_utils/load.py
+++ b/pycytominer/cyto_utils/load.py
@@ -83,7 +83,7 @@ def load_platemap(platemap, add_metadata_id=True):
     return platemap
 
 
-def load_npz_features(npz_file, fallback_feature_prefix="DP"):
+def load_npz_features(npz_file, fallback_feature_prefix="DP", metadata=True):
     """
     Load an npz file storing features and, sometimes, metadata.
 
@@ -114,6 +114,9 @@ def load_npz_features(npz_file, fallback_feature_prefix="DP"):
 
     # Load features
     df = pd.DataFrame(npz["features"])
+    
+    if not metadata:
+        return df
 
     # Load metadata
     if "metadata" in files:
@@ -144,7 +147,7 @@ def load_npz_features(npz_file, fallback_feature_prefix="DP"):
     return df
 
 
-def load_npz_locations(npz_file):
+def load_npz_locations(npz_file, location_columns = (0,1)):
     """
     Load an npz file storing locations and, sometimes, metadata.
 
@@ -158,6 +161,8 @@ def load_npz_locations(npz_file):
     ----------
     npz_file : str
         file path to the compressed output (typically DeepProfiler output)
+    location_columns : tuple
+        (location_center_x column number, location_center_y column number), column numbers for location data
 
     Return
     ------
@@ -170,12 +175,13 @@ def load_npz_locations(npz_file):
         return pd.DataFrame([])
 
     files = npz.files
-
-    # Load features
+    
     try:
         df = pd.DataFrame(
-            npz["locations"], columns=["Location_Center_X", "Location_Center_Y"]
+            npz["locations"]
         )
+        df = df[[location_columns[0], location_columns[1]]]
+        df.columns = ["Location_Center_X", "Location_Center_Y"]
         return df
     except:
         return pd.DataFrame()

--- a/pycytominer/cyto_utils/load.py
+++ b/pycytominer/cyto_utils/load.py
@@ -184,10 +184,7 @@ def load_npz_locations(npz_file, location_x_col_index=0, location_y_col_index=1)
     if location_y_col_index >= num_location_cols:
         raise IndexError("OutOfBounds indexing via location_y_col_index")
 
-    try:
-        df = pd.DataFrame(npz["locations"])
-        df = df[[location_x_col_index, location_y_col_index]]
-        df.columns = ["Location_Center_X", "Location_Center_Y"]
-        return df
-    except:
-        return pd.DataFrame()
+    df = pd.DataFrame(npz["locations"])
+    df = df[[location_x_col_index, location_y_col_index]]
+    df.columns = ["Location_Center_X", "Location_Center_Y"]
+    return df

--- a/pycytominer/cyto_utils/load.py
+++ b/pycytominer/cyto_utils/load.py
@@ -114,7 +114,7 @@ def load_npz_features(npz_file, fallback_feature_prefix="DP", metadata=True):
 
     # Load features
     df = pd.DataFrame(npz["features"])
-    
+
     if not metadata:
         return df
 
@@ -147,7 +147,7 @@ def load_npz_features(npz_file, fallback_feature_prefix="DP", metadata=True):
     return df
 
 
-def load_npz_locations(npz_file, location_columns = (0,1)):
+def load_npz_locations(npz_file, location_columns=(0, 1)):
     """
     Load an npz file storing locations and, sometimes, metadata.
 
@@ -175,11 +175,9 @@ def load_npz_locations(npz_file, location_columns = (0,1)):
         return pd.DataFrame([])
 
     files = npz.files
-    
+
     try:
-        df = pd.DataFrame(
-            npz["locations"]
-        )
+        df = pd.DataFrame(npz["locations"])
         df = df[[location_columns[0], location_columns[1]]]
         df.columns = ["Location_Center_X", "Location_Center_Y"]
         return df

--- a/pycytominer/cyto_utils/load.py
+++ b/pycytominer/cyto_utils/load.py
@@ -177,11 +177,11 @@ def load_npz_locations(npz_file, location_x_col_index=0, location_y_col_index=1)
         return pd.DataFrame([])
 
     # number of columns with data in the locations file
-    location_cols = npz["locations"].shape[1]
+    num_location_cols = npz["locations"].shape[1]
     # throw error if user tries to index columns that don't exist
-    if location_x_col_index >= location_cols:
+    if location_x_col_index >= num_location_cols:
         raise IndexError("OutOfBounds indexing via location_x_col_index")
-    if location_y_col_index >= location_cols:
+    if location_y_col_index >= num_location_cols:
         raise IndexError("OutOfBounds indexing via location_y_col_index")
 
     try:

--- a/pycytominer/cyto_utils/load.py
+++ b/pycytominer/cyto_utils/load.py
@@ -147,7 +147,7 @@ def load_npz_features(npz_file, fallback_feature_prefix="DP", metadata=True):
     return df
 
 
-def load_npz_locations(npz_file, location_x_col_index = 0, location_y_col_index = 1):
+def load_npz_locations(npz_file, location_x_col_index=0, location_y_col_index=1):
     """
     Load an npz file storing locations and, sometimes, metadata.
 
@@ -176,7 +176,13 @@ def load_npz_locations(npz_file, location_x_col_index = 0, location_y_col_index 
     except FileNotFoundError:
         return pd.DataFrame([])
 
-    files = npz.files
+    # number of columns with data in the locations file
+    location_cols = npz["locations"].shape[1]
+    # throw error if user tries to index columns that don't exist
+    if location_x_col_index >= location_cols:
+        raise IndexError("OutOfBounds indexing via location_x_col_index")
+    if location_y_col_index >= location_cols:
+        raise IndexError("OutOfBounds indexing via location_y_col_index")
 
     try:
         df = pd.DataFrame(npz["locations"])

--- a/pycytominer/tests/test_cyto_utils/test_load.py
+++ b/pycytominer/tests/test_cyto_utils/test_load.py
@@ -182,3 +182,17 @@ def test_load_npz():
         "Location_Center_X",
         "Location_Center_Y",
     ]
+
+    # Check that column locations out of bounds throw error
+    with pytest.raises(
+        IndexError, match="OutOfBounds indexing via location_x_col_index"
+    ):
+        load_npz_locations(
+            example_npz_file_locations, location_x_col_index=2, location_y_col_index=1
+        )
+    with pytest.raises(
+        IndexError, match="OutOfBounds indexing via location_y_col_index"
+    ):
+        load_npz_locations(
+            example_npz_file_locations, location_x_col_index=0, location_y_col_index=2
+        )


### PR DESCRIPTION
Co-authored-by: Jenna Tomkinson <jenna.tomkinson@ucdenver.edu>

# Description

Added optional parameter to allow user to set columns for center X, Y coordinates when loading locations from DeepProfiler (DP) output files. Currently, PyCytominer only reads the first two columns from the DP locations output. This PR allows a user to specify which columns to look at when loading locations from the DP npz output files. This PR also allows a user to specify location columns when compiling a single cell dataframe from DP data.

Please also link to any relevant issues that your code is associated with.

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [X] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have deleted all non-relevant text in this pull request template.

@gwaybio This is ready for review!