### PR TITLE
Reduce memory consumption of SingleCells.merge_single_cells

### DIFF
--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -419,13 +419,16 @@ class SingleCells(object):
 
         return meta_cols, feat_cols
 
-    def load_compartment(self, compartment):
+    def load_compartment(self, compartment, float_datatype: type = np.float64):
         """Creates the compartment dataframe.
 
         Parameters
         ----------
         compartment : str
             The compartment to process.
+        float_datatype: type, default np.float64
+            Numpy floating point datatype to use for load_compartment and resulting dataframes.
+            Please note: using any besides np.float64 are experimentally unverified.
 
         Returns
         -------
@@ -439,7 +442,7 @@ class SingleCells(object):
         num_meta, num_feats = len(meta_cols), len(feat_cols)
 
         # Use pre-allocated np.array for data
-        feats = np.empty(shape=(num_cells, num_feats), dtype=np.float64)
+        feats = np.empty(shape=(num_cells, num_feats), dtype=float_datatype)
         # Use pre-allocated pd.DataFrame for metadata
         metas = pd.DataFrame(columns=meta_cols, index=range(num_cells))
 
@@ -653,6 +656,7 @@ class SingleCells(object):
         normalize_args: Optional[Dict] = None,
         platemap: Optional[Union[str, pd.DataFrame]] = None,
         sc_merge_chunksize: Optional[int] = None,
+        float_datatype: type = np.float64,
         **kwargs,
     ):
         """Given the linking columns, merge single cell data. Normalization is also supported.
@@ -677,6 +681,9 @@ class SingleCells(object):
             Chunksize for merge and concatenation operations to help address performance issues
             note: if set to None, will infer a chunksize which is the roughly 1/3 the row length
             of first component df.
+        float_datatype: type, default np.float64
+            Numpy floating point datatype to use for load_compartment and resulting dataframes.
+            Please note: using any besides np.float64 are experimentally unverified.
 
         Returns
         -------
@@ -710,7 +717,9 @@ class SingleCells(object):
                 ]
 
                 if sc_df.empty:
-                    sc_df = self.load_compartment(compartment=left_compartment)
+                    sc_df = self.load_compartment(
+                        compartment=left_compartment, float_datatype=float_datatype
+                    )
 
                     # if chunksize was not set, set it to roughly
                     # one third the size of our initial compartment
@@ -733,7 +742,9 @@ class SingleCells(object):
                 # sc_merge_chunksize to help constrain memory
                 sc_df = pd.concat(
                     [
-                        self.load_compartment(compartment=right_compartment).merge(
+                        self.load_compartment(
+                            compartment=right_compartment, float_datatype=float_datatype
+                        ).merge(
                             right=right_chunk,
                             # note: we reverse left and right for join key merge order reference
                             left_on=self.merge_cols + [right_link_col],

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -712,7 +712,8 @@ class SingleCells(object):
                 if sc_df.empty:
                     sc_df = self.load_compartment(compartment=left_compartment)
 
-                    # if chunksize was not set,
+                    # if chunksize was not set, set it to roughly
+                    # one third the size of our initial compartment
                     if chunksize is None:
                         chunksize = round(len(sc_df) / 3)
 

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -652,7 +652,7 @@ class SingleCells(object):
         single_cell_normalize: bool = False,
         normalize_args: Optional[Dict] = None,
         platemap: Optional[Union[str, pd.DataFrame]] = None,
-        chunksize: Optional[int] = None,
+        sc_merge_chunksize: Optional[int] = None,
         **kwargs,
     ):
         """Given the linking columns, merge single cell data. Normalization is also supported.
@@ -734,7 +734,7 @@ class SingleCells(object):
                 sc_df = pd.concat(
                     [
                         self.load_compartment(compartment=right_compartment).merge(
-                            right=right,
+                            right=right_chunk,
                             # note: we reverse left and right for join key merge order reference
                             left_on=self.merge_cols + [right_link_col],
                             right_on=self.merge_cols + [left_link_col],
@@ -742,7 +742,7 @@ class SingleCells(object):
                             suffixes=reversed(merge_suffix),
                             how="inner",
                         )
-                        for right in [
+                        for right_chunk in [
                             sc_df[i : i + chunksize]
                             for i in range(0, sc_df.shape[0], chunksize)
                         ]

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -309,6 +309,7 @@ def test_merge_single_cells():
         "Metadata_ObjectNumber_cytoplasm",
         "Metadata_ObjectNumber_cells",
     ]
+
     # check that we have the same data using same cols, sort and a reset index
     pd.testing.assert_frame_equal(
         left=manual_merge[assert_cols]

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -3,6 +3,7 @@ import pathlib
 import random
 import tempfile
 
+import numpy as np
 import pandas as pd
 import pytest
 from pycytominer import aggregate, annotate, normalize
@@ -252,6 +253,23 @@ def test_load_compartment():
     pd.testing.assert_frame_equal(
         NEW_COMPARTMENT_DF.reindex(columns=loaded_compartment_df.columns),
         loaded_compartment_df,
+        check_dtype=False,
+    )
+
+    # test using non-default float_datatype
+    loaded_compartment_df = AP.load_compartment(
+        compartment="cells", float_datatype=np.float32
+    )
+    pd.testing.assert_frame_equal(
+        loaded_compartment_df,
+        CELLS_DF.astype(
+            # cast any float type columns to float32 for expected comparison
+            {
+                colname: np.float32
+                for colname in CELLS_DF.columns
+                if pd.api.types.is_float(CELLS_DF[colname].dtype)
+            }
+        ).reindex(columns=loaded_compartment_df.columns),
         check_dtype=False,
     )
 

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -339,6 +339,28 @@ def test_merge_single_cells():
         check_dtype=False,
     )
 
+    # use non-default float_datatype
+    sc_merged_df = AP.merge_single_cells(float_datatype=np.float32)
+
+    # similar to the assert above, we test non-default float dtype specification
+    pd.testing.assert_frame_equal(
+        left=manual_merge[assert_cols]
+        .astype(
+            # cast any float type columns to float32 for expected comparison
+            {
+                colname: np.float32
+                for colname in manual_merge.columns
+                if pd.api.types.is_float(manual_merge[colname].dtype)
+            }
+        )
+        .sort_values(by=assert_cols, ascending=True)
+        .reset_index(drop=True),
+        right=sc_merged_df[assert_cols]
+        .sort_values(by=assert_cols, ascending=True)
+        .reset_index(drop=True),
+        check_dtype=False,
+    )
+
     # Confirm the merge and adding merge options
     for method in ["standardize", "robustize"]:
         for samples in ["all", "Metadata_ImageNumber == 'x'"]:


### PR DESCRIPTION
# Description

These changes seek to address #233 memory challenges when using `SingleCells.merge_single_cells` by segmenting Pandas merges using dynamic argument `chunksize` and related dataframe concatenation within the method. In brief testing using small datasets with these changes I saw around 12-18% reduction in peak memory use (using `chunksize` default).

Using this segmented merge approach we're making a tradeoff between memory and time; in large data scenarios we may avoid out-of-memory issues and the procedure may take longer due to more (but smaller) merges being required. `chunksize` is an optional argument which when left to it's default of `None` will automatically be set to 1/3rd of the first compartment dataframe rowlength. Performance may vary with `chunksize` contingent on the dataset and is the reasoning for this being an argument which may be optionally set by a developer.

__Caveats:__
- Leveraging existing suffix column naming within the merges along with the increase in number of merges increases the number of warnings emitted during testing. (`FutureWarning: Passing 'suffixes' which cause duplicate columns {'ObjectNumber_cytoplasm'} in the result is deprecated and will raise a MergeError in a future version.`).
- Testing via `test_cells.py` needed updates in order for the changes within `cells.py` to pass pytesting. With these changes I focused on ensuring the data itself was as expected. I'd ask for double-checks here especially to make sure everything looks good.
- Performance will likely vary based on the resources of the system running pycytominer and the dataset involved. Using the `chunksize` default does not guarantee avoidance of out-of-memory issues and instead provides flexibility for developer implementation.

Thank you @axiomcura for the excellent writeup on the performance issue!

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings. (see caveats above)
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
