### PR TITLE
Change drop_outlier default to 500

### DIFF
--- a/pycytominer/cyto_utils/features.py
+++ b/pycytominer/cyto_utils/features.py
@@ -142,7 +142,7 @@ def count_na_features(population_df, features):
 
 
 def drop_outlier_features(
-    population_df, features="infer", samples="all", outlier_cutoff=15
+    population_df, features="infer", samples="all", outlier_cutoff=500
 ):
     """Exclude a feature if its min or max absolute value is greater than the threshold.
 
@@ -154,7 +154,7 @@ def drop_outlier_features(
         Features present in the population dataframe. If "infer", then assume Cell Painting features are those that start with "Cells_", "Nuclei_", or "Cytoplasm_"
     samples : list of str or str, default "all"
         Samples to perform the operation on
-    outlier_cutoff : int or float, default 15
+    outlier_cutoff : int or float, default 500
         Threshold to remove features if absolute values is greater
 
     Returns

--- a/pycytominer/cyto_utils/features.py
+++ b/pycytominer/cyto_utils/features.py
@@ -155,6 +155,7 @@ def drop_outlier_features(
     samples : list of str or str, default "all"
         Samples to perform the operation on
     outlier_cutoff : int or float, default 500
+    see https://github.com/cytomining/pycytominer/issues/237 for details.
         Threshold to remove features if absolute values is greater
 
     Returns

--- a/pycytominer/feature_select.py
+++ b/pycytominer/feature_select.py
@@ -35,7 +35,7 @@ def feature_select(
     compression_options=None,
     float_format=None,
     blocklist_file=None,
-    outlier_cutoff=15,
+    outlier_cutoff=500,
     noise_removal_perturb_groups=None,
     noise_removal_stdev_cutoff=None,
 ):
@@ -84,8 +84,8 @@ def feature_select(
         decimal precision.
     blocklist_file : str, optional
         File location of datafrmame with with features to exclude. Note that if "blocklist" in operation then will remove standard blocklist
-    outlier_cutoff : float, default 15
-        The threshold at which the maximum or minimum value of a feature across a full experiment is excluded. Note that this procedure is typically applied (and therefore the default is uitable) for after normalization.
+    outlier_cutoff : float, default 500
+        The threshold at which the maximum or minimum value of a feature across a full experiment is excluded. Note that this procedure is typically applied after normalization.
     noise_removal_perturb_groups: str or list of str, optional
         Perturbation groups corresponding to rows in profiles or the the name of the metadata column containing this information.
     noise_removal_stdev_cutoff: float,optional

--- a/pycytominer/tests/test_cyto_utils/test_feature_drop_outlier.py
+++ b/pycytominer/tests/test_cyto_utils/test_feature_drop_outlier.py
@@ -23,29 +23,34 @@ data_df = pd.DataFrame(
         "Cells_x": [1, 2, -8, 2, 5, 5, 5, -1],
         "Cytoplasm_y": [3, -1, 7, 4, 5, -9, 6, 1],
         "Nuclei_z": [-1, 8, 2, 5, -6, 20, 2, -2],
-        "Cells_zz": [14, -46, 1, 60, -30, -100, 2, 2],
+        "Cells_zz": [14, -46, 1, 60, -30, -10000, 2, 2],
     }
 ).reset_index(drop=True)
 
 
 def test_outlier_default():
     result = drop_outlier_features(data_df)
-    expected_result = ["Cells_zz", "Nuclei_z"]
+    expected_result = ["Cells_zz"]
     assert sorted(result) == sorted(expected_result)
 
 
-def test_outlier_high_cutoff():
+def test_outlier_30_cutoff():
     result = drop_outlier_features(data_df, outlier_cutoff=30)
     expected_result = ["Cells_zz"]
     assert result == expected_result
 
-
-def test_outlier_samples():
-    result = drop_outlier_features(data_df, samples=[0, 1, 2, 3, 5])
+def test_outlier_15_cutoff():
+    result = drop_outlier_features(data_df, outlier_cutoff=15)
     expected_result = ["Cells_zz", "Nuclei_z"]
     assert sorted(result) == sorted(expected_result)
 
-    result = drop_outlier_features(data_df, samples=[0, 1, 2, 3])
+
+def test_outlier_samples_15():
+    result = drop_outlier_features(data_df, samples=[0, 1, 2, 3, 5], outlier_cutoff=15)
+    expected_result = ["Cells_zz", "Nuclei_z"]
+    assert sorted(result) == sorted(expected_result)
+
+    result = drop_outlier_features(data_df, samples=[0, 1, 2, 3], outlier_cutoff=15)
     expected_result = ["Cells_zz"]
     assert result == expected_result
 

--- a/pycytominer/tests/test_cyto_utils/test_feature_drop_outlier.py
+++ b/pycytominer/tests/test_cyto_utils/test_feature_drop_outlier.py
@@ -34,11 +34,6 @@ def test_outlier_default():
     assert sorted(result) == sorted(expected_result)
 
 
-def test_outlier_30_cutoff():
-    result = drop_outlier_features(data_df, outlier_cutoff=30)
-    expected_result = ["Cells_zz"]
-    assert result == expected_result
-
 def test_outlier_15_cutoff():
     result = drop_outlier_features(data_df, outlier_cutoff=15)
     expected_result = ["Cells_zz", "Nuclei_z"]

--- a/pycytominer/tests/test_feature_select.py
+++ b/pycytominer/tests/test_feature_select.py
@@ -67,7 +67,7 @@ data_outlier_df = pd.DataFrame(
         "Cells_x": [1, 2, -8, 2, 5, 5, 5, -1],
         "Cytoplasm_y": [3, -1, 7, 4, 5, -9, 6, 1],
         "Nuclei_z": [-1, 8, 2, 5, -6, 20, 2, -2],
-        "Cells_zz": [14, -46, 1, 60, -30, -100, 2, 2],
+        "Cells_zz": [14, -46, 1, 60, -30, -10000, 2, 2],
     }
 ).reset_index(drop=True)
 
@@ -425,7 +425,7 @@ def test_feature_select_drop_outlier():
     result = feature_select(
         data_outlier_df, features="infer", operation="drop_outliers"
     )
-    expected_result = data_outlier_df.drop(["Cells_zz", "Nuclei_z"], axis="columns")
+    expected_result = data_outlier_df.drop(["Cells_zz"], axis="columns")
     pd.testing.assert_frame_equal(result, expected_result)
 
     result = feature_select(
@@ -435,6 +435,6 @@ def test_feature_select_drop_outlier():
     pd.testing.assert_frame_equal(result, expected_result)
 
     result = feature_select(
-        data_outlier_df, features=["Cells_x", "Cytoplasm_y"], operation="drop_outliers"
+        data_outlier_df, features=["Cells_x", "Cytoplasm_y"], operation="drop_outliers", outlier_cutoff=15
     )
     pd.testing.assert_frame_equal(result, data_outlier_df)


### PR DESCRIPTION
_modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_

# Description
Resolves #237 by changing the drop_outliers default cutoff from 15 to 500, for reasons more thoroughly detailed in that issue. 

## What is the nature of your change?

- [x] Bug fix (fixes an issue).

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
