### PR TITLE
avoid re-validation for excluded features

### DIFF
--- a/pycytominer/feature_select.py
+++ b/pycytominer/feature_select.py
@@ -176,6 +176,7 @@ def feature_select(
                 noise_removal_stdev_cutoff=noise_removal_stdev_cutoff,
             )
         excluded_features += exclude
+        features = [feat for feat in features if feat not in excluded_features]
 
     excluded_features = list(set(excluded_features))
 

--- a/pycytominer/feature_select.py
+++ b/pycytominer/feature_select.py
@@ -1,10 +1,6 @@
 """
 Select features to use in downstream analysis based on specified selection method
 """
-
-import os
-import pandas as pd
-
 from pycytominer.operations import (
     correlation_threshold,
     variance_threshold,

--- a/pycytominer/tests/test_feature_select.py
+++ b/pycytominer/tests/test_feature_select.py
@@ -326,7 +326,7 @@ def test_feature_select_correlation_threshold():
         features=data_cor_thresh_na_df.columns.tolist(),
         operation=["drop_na_columns", "correlation_threshold"],
     )
-    expected_result = data_df.drop(["z", "x"], axis="columns")
+    expected_result = data_df.drop(["z", "y"], axis="columns")
     pd.testing.assert_frame_equal(result, expected_result)
 
 


### PR DESCRIPTION
If an `operation` excluded a column, such column should not be validated by further `operation`s. This will reduce the computation time. It will benefit list of operations sorted by computational cost (ascending).

## What is the nature of your change?

- [X] Enhancement (speed).
- [ ] This change requires a documentation update. Maybe explain the benefits of sorting operations by computational cost.

# Checklist

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have deleted all non-relevant text in this pull request template.