### PR TITLE
Add float_datatype parameter for SingleCells compartment load and merge performance flexibility

### DIFF
--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -429,13 +429,17 @@ class SingleCells(object):
 
         return meta_cols, feat_cols
 
-    def load_compartment(self, compartment):
+    def load_compartment(self, compartment, float_datatype: type = np.float64):
         """Creates the compartment dataframe.
 
         Parameters
         ----------
         compartment : str
             The compartment to process.
+        float_datatype: type, default np.float64
+            Numpy floating point datatype to use for load_compartment and resulting
+            dataframes. Please note: using any besides np.float64 are experimentally
+            unverified.
 
         Returns
         -------
@@ -448,8 +452,8 @@ class SingleCells(object):
         meta_cols, feat_cols = self.get_sql_table_col_names(compartment)
         num_meta, num_feats = len(meta_cols), len(feat_cols)
 
-        # Use pre-allocated np.array for data
-        feats = np.empty(shape=(num_cells, num_feats), dtype=np.float64)
+        # Use pre-allocated np.array for feature data
+        feats = np.empty(shape=(num_cells, num_feats), dtype=float_datatype)
         # Use pre-allocated pd.DataFrame for metadata
         metas = pd.DataFrame(columns=meta_cols, index=range(num_cells))
 
@@ -661,6 +665,7 @@ class SingleCells(object):
         single_cell_normalize: bool = False,
         normalize_args: Optional[Dict] = None,
         platemap: Optional[Union[str, pd.DataFrame]] = None,
+        float_datatype: type = np.float64,
         **kwargs,
     ):
         """Given the linking columns, merge single cell data. Normalization is also supported.
@@ -681,6 +686,10 @@ class SingleCells(object):
             Additional arguments passed as input to pycytominer.normalize().
         platemap: str or pd.DataFrame, default None
             optional platemap filepath str or pd.DataFrame to be used with results via annotate
+        float_datatype: type, default np.float64
+            Numpy floating point datatype to use for load_compartment and resulting
+            dataframes. Please note: using any besides np.float64 are experimentally
+            unverified.
 
         Returns
         -------
@@ -714,7 +723,9 @@ class SingleCells(object):
                 ]
 
                 if isinstance(sc_df, str):
-                    sc_df = self.load_compartment(compartment=left_compartment)
+                    sc_df = self.load_compartment(
+                        compartment=left_compartment, float_datatype=float_datatype
+                    )
 
                     if compute_subsample:
                         # Sample cells proportionally by self.strata
@@ -729,7 +740,9 @@ class SingleCells(object):
                         ).reindex(sc_df.columns, axis="columns")
 
                     sc_df = sc_df.merge(
-                        self.load_compartment(compartment=right_compartment),
+                        self.load_compartment(
+                            compartment=right_compartment, float_datatype=float_datatype
+                        ),
                         left_on=self.merge_cols + [left_link_col],
                         right_on=self.merge_cols + [right_link_col],
                         suffixes=merge_suffix,
@@ -737,7 +750,9 @@ class SingleCells(object):
 
                 else:
                     sc_df = sc_df.merge(
-                        self.load_compartment(compartment=right_compartment),
+                        self.load_compartment(
+                            compartment=right_compartment, float_datatype=float_datatype
+                        ),
                         left_on=self.merge_cols + [left_link_col],
                         right_on=self.merge_cols + [right_link_col],
                         suffixes=merge_suffix,

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -753,7 +753,7 @@ class SingleCells(object):
                 else:
                     sc_df = sc_df.merge(
                         self.load_compartment(
-                            compartment=right_compartment, float_datatype=float_datatype
+                            compartment=right_compartment
                         ),
                         left_on=self.merge_cols + [left_link_col],
                         right_on=self.merge_cols + [right_link_col],

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -69,6 +69,14 @@ class SingleCells(object):
         Name of the fields of view feature.
     object_feature : str, default "Metadata_ObjectNumber"
         Object number feature.
+    default_datatype_float: type
+        Numpy floating point datatype to use for load_compartment and resulting
+        dataframes. This parameter may be used to assist with performance-related
+        issues by reducing the memory required for floating-point data. 
+        For example, using np.float32 instead of np.float64 for this parameter 
+        will reduce memory consumed by float columns by roughly 50%.
+        Please note: using any besides np.float64 are experimentally
+        unverified.
 
     Notes
     -----
@@ -105,6 +113,7 @@ class SingleCells(object):
         fields_of_view="all",
         fields_of_view_feature="Metadata_Site",
         object_feature="Metadata_ObjectNumber",
+        default_datatype_float=np.float64,
     ):
         """Constructor method"""
         # Check compartments specified
@@ -139,6 +148,7 @@ class SingleCells(object):
         self.compartment_linking_cols = compartment_linking_cols
         self.fields_of_view_feature = fields_of_view_feature
         self.object_feature = object_feature
+        self.default_datatype_float = default_datatype_float
 
         # Confirm that the compartments and linking cols are formatted properly
         assert_linking_cols_complete(
@@ -429,17 +439,16 @@ class SingleCells(object):
 
         return meta_cols, feat_cols
 
-    def load_compartment(self, compartment, float_datatype: type = np.float64):
+    def load_compartment(self, compartment):
         """Creates the compartment dataframe.
+
+        Note: makes use of default_datatype_float attribute
+        for setting a default floating point datatype.
 
         Parameters
         ----------
         compartment : str
             The compartment to process.
-        float_datatype: type, default np.float64
-            Numpy floating point datatype to use for load_compartment and resulting
-            dataframes. Please note: using any besides np.float64 are experimentally
-            unverified.
 
         Returns
         -------
@@ -453,7 +462,9 @@ class SingleCells(object):
         num_meta, num_feats = len(meta_cols), len(feat_cols)
 
         # Use pre-allocated np.array for feature data
-        feats = np.empty(shape=(num_cells, num_feats), dtype=float_datatype)
+        feats = np.empty(
+            shape=(num_cells, num_feats), dtype=self.default_datatype_float
+        )
         # Use pre-allocated pd.DataFrame for metadata
         metas = pd.DataFrame(columns=meta_cols, index=range(num_cells))
 
@@ -665,7 +676,6 @@ class SingleCells(object):
         single_cell_normalize: bool = False,
         normalize_args: Optional[Dict] = None,
         platemap: Optional[Union[str, pd.DataFrame]] = None,
-        float_datatype: type = np.float64,
         **kwargs,
     ):
         """Given the linking columns, merge single cell data. Normalization is also supported.
@@ -686,10 +696,6 @@ class SingleCells(object):
             Additional arguments passed as input to pycytominer.normalize().
         platemap: str or pd.DataFrame, default None
             optional platemap filepath str or pd.DataFrame to be used with results via annotate
-        float_datatype: type, default np.float64
-            Numpy floating point datatype to use for load_compartment and resulting
-            dataframes. Please note: using any besides np.float64 are experimentally
-            unverified.
 
         Returns
         -------
@@ -723,9 +729,7 @@ class SingleCells(object):
                 ]
 
                 if isinstance(sc_df, str):
-                    sc_df = self.load_compartment(
-                        compartment=left_compartment, float_datatype=float_datatype
-                    )
+                    sc_df = self.load_compartment(compartment=left_compartment)
 
                     if compute_subsample:
                         # Sample cells proportionally by self.strata
@@ -740,9 +744,7 @@ class SingleCells(object):
                         ).reindex(sc_df.columns, axis="columns")
 
                     sc_df = sc_df.merge(
-                        self.load_compartment(
-                            compartment=right_compartment, float_datatype=float_datatype
-                        ),
+                        self.load_compartment(compartment=right_compartment),
                         left_on=self.merge_cols + [left_link_col],
                         right_on=self.merge_cols + [right_link_col],
                         suffixes=merge_suffix,

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -303,22 +303,25 @@ def test_load_compartment():
     # for uniformly handling metadata types for both dataframes
     metadata_types = {"ObjectNumber": "int64"}
 
+    # updated column datatypes for manual comparisons with CELLS_DF
+    cells_df_comparison_types = {
+        colname: np.float32
+        for colname in CELLS_DF.columns
+        # check for only columns which are of float type
+        if pd.api.types.is_float(CELLS_DF[colname].dtype)
+        # check for columns which are of 'int64' type
+        # note: pd.api.types.is_integer sometimes is unable to detect int64
+        or CELLS_DF[colname].dtype == "int64"
+        # avoid recasting the metadata_types
+        and colname not in metadata_types.keys()
+    }
+
     # create deep copy of CELLS_DF with manually re-typed float columns as float32
-    cells_df_for_compare = CELLS_DF.copy(deep=True).astype(
-        # cast any float type columns to float32 for expected comparison
-        {
-            colname: np.float32
-            for colname in CELLS_DF.columns
-            # check for only columns which are of float type
-            if pd.api.types.is_float(CELLS_DF[colname].dtype)
-            # check for columns which are of 'int64' type
-            # note: pd.api.types.is_integer sometimes is unable to detect int64
-            or CELLS_DF[colname].dtype == "int64"
-            # avoid recasting the metadata_types
-            and colname not in metadata_types.keys()
-        }
-        # use float32_loaded_compartment_df column order for comparison below
-    )[float32_loaded_compartment_df.columns]
+    # and cast any float type columns to float32 for expected comparison
+    cells_df_for_compare = CELLS_DF.copy(deep=True).astype(cells_df_comparison_types)[
+        # use float32_loaded_compartment_df column order for comparison
+        float32_loaded_compartment_df.columns
+    ]
 
     # cast metadata types in the same way for comparisons
     float32_loaded_compartment_df = float32_loaded_compartment_df.astype(metadata_types)

--- a/pycytominer/tests/test_cyto_utils/test_cells.py
+++ b/pycytominer/tests/test_cyto_utils/test_cells.py
@@ -1080,11 +1080,3 @@ def test_load_non_canonical_image_table():
         sc_aggregated_df,
     )
 
-def test_singlecells_default_datatype():
-    """
-    Testing various use of SingleCells class attribute
-    default_datatype_float with non-default options.
-    """
-
-
-


### PR DESCRIPTION
# Description

This change adds a float_datatype parameter for use with SingleCells compartment load and merge operations to assist with performance considerations (as cited within wayscience/cell-health-data#10 and other areas). In testing this locally using `np.float32` instead of `np.float64` I found ~45% reduction in peak memory consumption while running `merge_single_cells` on small testing datasets (this reduction may vary contingent on dataset).

This change is also related to #198 and #227 (if only to notate datatype considerations).

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
