### PR TITLE
pin scipy <1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.16.5
-scipy>=1.3.0
+scipy>=1.3.0,<1.9
 pandas>=1.2.0
 scikit-learn>=0.21.2
 sqlalchemy>=1.3.6,<2


### PR DESCRIPTION
pycytominer aggregate calls median_absolute_deviation from scipy.stats and median_absolute_deviation was removed from scipy.stats in 1.9.0

Currently if I run `from pycytominer import aggregate` with `scipy == 1.10.0` I get the error `ImportError: cannot import name 'median_absolute_deviation' from 'scipy.stats' `

## What is the nature of your change?

- [x ] Bug fix (fixes an issue).