### PR TITLE
make default `unique_cut` value for `variance_threshold` consistent with `feature_select`

### DIFF
--- a/pycytominer/operations/variance_threshold.py
+++ b/pycytominer/operations/variance_threshold.py
@@ -9,7 +9,7 @@ from pycytominer.cyto_utils import infer_cp_features
 
 
 def variance_threshold(
-    population_df, features="infer", samples="all", freq_cut=0.05, unique_cut=0.01
+    population_df, features="infer", samples="all", freq_cut=0.05, unique_cut=0.1
 ):
     """Exclude features that have low variance (low information content)
 


### PR DESCRIPTION
Quickfix for #282 making defaults consistent. Related tests pass.
