### PR TITLE
load_profiles should work with PurePath types

### DIFF
--- a/pycytominer/tests/test_cyto_utils/test_load.py
+++ b/pycytominer/tests/test_cyto_utils/test_load.py
@@ -1,6 +1,6 @@
 import os
 import random
-import pytest
+import pathlib
 import tempfile
 import numpy as np
 import pandas as pd
@@ -138,6 +138,19 @@ def test_load_profiles():
 
     profiles_from_frame = load_profiles(data_df)
     pd.testing.assert_frame_equal(data_df, profiles_from_frame)
+
+
+def test_load_profiles_type_check():
+    data_file_os = os.path.join(tmpdir, "test_data.csv")
+    data_file_path = pathlib.Path(tmpdir, "test_data.csv")
+    data_file_purepath = pathlib.PurePath(tmpdir, "test_data.csv")
+
+    profiles_os = load_profiles(data_file_os)
+    profiles_path = load_profiles(data_file_path)
+    profiles_purepath = load_profiles(data_file_purepath)
+
+    pd.testing.assert_frame_equal(profiles_os, profiles_path)
+    pd.testing.assert_frame_equal(profiles_purepath, profiles_path)
 
 
 def test_load_platemap():


### PR DESCRIPTION
# Description

Fixing the issue @ErinWeisbart described in #284 - the issue is within the `load_profiles()` function and a type check that fails to account for `pathlib.PurePath()` objects.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
