### PR TITLE
Change variance_threshold default to 0.01

### DIFF
--- a/pycytominer/feature_select.py
+++ b/pycytominer/feature_select.py
@@ -27,7 +27,7 @@ def feature_select(
     corr_threshold=0.9,
     corr_method="pearson",
     freq_cut=0.05,
-    unique_cut=0.1,
+    unique_cut=0.01,
     compression_options=None,
     float_format=None,
     blocklist_file=None,

--- a/pycytominer/operations/variance_threshold.py
+++ b/pycytominer/operations/variance_threshold.py
@@ -9,7 +9,7 @@ from pycytominer.cyto_utils import infer_cp_features
 
 
 def variance_threshold(
-    population_df, features="infer", samples="all", freq_cut=0.05, unique_cut=0.1
+    population_df, features="infer", samples="all", freq_cut=0.05, unique_cut=0.01
 ):
     """Exclude features that have low variance (low information content)
 


### PR DESCRIPTION
# Description

From: https://github.com/cytomining/pycytominer/issues/282

> I noticed that `variance_threshold` [always had](https://github.com/cytomining/pycytominer/blame/69f5953800cd3e7b5e2eb73447c8028c8660356c/pycytominer/variance_threshold.py#L7) `unique_cut=0.01` as a default, while `feature_select` [later set](https://github.com/cytomining/pycytominer/commit/50233cf4e2e0a586526c167764b75ebccdac82a9#diff-9663e5e233193c07b7da5bf152568cc107832af78e2e025eb3b803225d5c39feR25) more strict default `unique_cut=0.1`, overriding that of `variance_threshold`.

The threshold of 0.1 is too high; I think we should change the default to 0.01. This might be a breaking change of sorts but this might be the right time to do it (given the upcoming v1.0.0). 

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
