### PR TITLE
Add "output_type" parameter to major functions

### DIFF
--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -17,6 +17,7 @@ def aggregate(
     features="infer",
     operation="median",
     output_file=None,
+    output_type="csv",
     compute_object_count=False,
     object_feature="Metadata_ObjectNumber",
     subset_data_df=None,
@@ -38,6 +39,9 @@ def aggregate(
     output_file : str or file handle, optional
         If provided, will write aggregated profiles to file. If not specified, will return the aggregated profiles.
         We recommend naming the file based on the plate name.
+    output_type : str, optional
+        If provided, will write aggregated profiles as a specified file type (either CSV or parquet).
+        If not specified and output_file is provided, then the file will be outputed as CSV as default.
     compute_object_count : bool, default False
         Whether or not to compute object counts.
     object_feature : str, default "Metadata_ObjectNumber"
@@ -117,6 +121,7 @@ def aggregate(
         output(
             df=population_df,
             output_filename=output_file,
+            output_type=output_type,
             compression_options=compression_options,
             float_format=float_format,
         )

--- a/pycytominer/annotate.py
+++ b/pycytominer/annotate.py
@@ -20,6 +20,7 @@ def annotate(
     platemap,
     join_on=["Metadata_well_position", "Metadata_Well"],
     output_file=None,
+    output_type="csv",
     add_metadata_id_to_platemap=True,
     format_broad_cmap=False,
     clean_cellprofiler=True,
@@ -42,7 +43,10 @@ def annotate(
     join_on : list or str, default: ["Metadata_well_position", "Metadata_Well"]
         Which variables to merge profiles and plate. The first element indicates variable(s) in platemap and the second element indicates variable(s) in profiles to merge using. Note the setting of `add_metadata_id_to_platemap`
     output_file : str, optional
-       If not specified, will return the annotated profiles. We recommend that this output file be suffixed with "_augmented.csv".
+        If not specified, will return the annotated profiles. We recommend that this output file be suffixed with "_augmented.csv".
+    output_type : str, optional
+        If provided, will write annotated profiles as a specified file type (either CSV or parquet).
+        If not specified and output_file is provided, then the file will be outputed as CSV as default.
     add_metadata_id_to_platemap : bool, default True
         Whether the plate map variables possibly need "Metadata" pre-pended
     format_broad_cmap : bool, default False
@@ -133,6 +137,7 @@ def annotate(
         output(
             df=annotated,
             output_filename=output_file,
+            output_type=output_type,
             compression_options=compression_options,
             float_format=float_format,
         )

--- a/pycytominer/consensus.py
+++ b/pycytominer/consensus.py
@@ -20,6 +20,7 @@ def consensus(
     operation="median",
     features="infer",
     output_file=None,
+    output_type="csv",
     compression_options=None,
     float_format=None,
     modz_args={"method": "spearman"},
@@ -42,6 +43,9 @@ def consensus(
     output_file : str, optional
         If provided, will write consensus profiles to file. If not specified, will
         return the normalized profiles as output.
+    output_type : str, optional
+        If provided, will write consensus profiles as a specified file type (either CSV or parquet).
+        If not specified and output_file is provided, then the file will be outputed as CSV as default.
     compression_options : str or dict, optional
         Contains compression options as input to
         pd.DataFrame.to_csv(compression=compression_options). pandas version >= 1.2.
@@ -120,6 +124,7 @@ def consensus(
         output(
             df=consensus_df,
             output_filename=output_file,
+            output_type=output_type,
             compression_options=compression_options,
             float_format=float_format,
         )

--- a/pycytominer/feature_select.py
+++ b/pycytominer/feature_select.py
@@ -23,6 +23,7 @@ def feature_select(
     samples="all",
     operation="variance_threshold",
     output_file=None,
+    output_type="csv",
     na_cutoff=0.05,
     corr_threshold=0.9,
     corr_method="pearson",
@@ -53,9 +54,12 @@ def feature_select(
     operation: list of str or str, default "variance_threshold
         Operations to perform on the input profiles.
     output_file : str, optional
-        If provided, will write annotated profiles to file. If not specified, will
-        return the normalized profiles as output. We recommend that this output file be
+        If provided, will write feature selected profiles to file. If not specified, will
+        return the feature selected profiles as output. We recommend that this output file be
         suffixed with "_normalized_variable_selected.csv".
+    output_type : str, optional
+        If provided, will write feature selected profiles as a specified file type (either CSV or parquet).
+        If not specified and output_file is provided, then the file will be outputed as CSV as default.
     na_cutoff : float, default 0.05
         Proportion of missing values in a column to tolerate before removing.
     corr_threshold : float, default 0.9
@@ -182,6 +186,7 @@ def feature_select(
         output(
             df=selected_df,
             output_filename=output_file,
+            output_type=output_type,
             compression_options=compression_options,
             float_format=float_format,
         )

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -21,6 +21,7 @@ def normalize(
     samples="all",
     method="standardize",
     output_file=None,
+    output_type="csv",
     compression_options=None,
     float_format=None,
     mad_robustize_epsilon=1e-18,
@@ -54,9 +55,12 @@ def normalize(
         How to normalize the dataframe. Defaults to "standardize". Check avail_methods
         for available normalization methods.
     output_file : str, optional
-        If provided, will write annotated profiles to file. If not specified, will
+        If provided, will write normalized profiles to file. If not specified, will
         return the normalized profiles as output. We recommend that this output file be
         suffixed with "_normalized.csv".
+    output_type : str, optional
+        If provided, will write normalized profiles as a specified file type (either CSV or parquet).
+        If not specified and output_file is provided, then the file will be outputed as CSV as default.
     compression_options : str or dict, optional
         Contains compression options as input to
         pd.DataFrame.to_csv(compression=compression_options). pandas version >= 1.2.
@@ -170,6 +174,7 @@ def normalize(
         output(
             df=normalized,
             output_filename=output_file,
+            output_type=output_type,
             compression_options=compression_options,
             float_format=float_format,
         )

--- a/pycytominer/tests/test_aggregate.py
+++ b/pycytominer/tests/test_aggregate.py
@@ -10,7 +10,8 @@ from pycytominer.cyto_utils import infer_cp_features
 tmpdir = tempfile.gettempdir()
 
 # Setup a testing file
-test_output_file = os.path.join(tmpdir, "test.csv")
+test_output_file1 = os.path.join(tmpdir, "test.csv")
+test_output_file2 = os.path.join(tmpdir, "test.parquet")
 
 # Build data to use in tests
 data_df = pd.concat(
@@ -73,10 +74,10 @@ def test_aggregate_median_allvar():
         strata=["g"],
         features="infer",
         operation="median",
-        output_file=test_output_file,
+        output_file=test_output_file1,
     )
 
-    test_df = pd.read_csv(test_output_file)
+    test_df = pd.read_csv(test_output_file1)
     pd.testing.assert_frame_equal(test_df, expected_result)
 
 
@@ -219,10 +220,10 @@ def test_aggregate_compute_object_count():
         features="infer",
         operation="median",
         compute_object_count=True,
-        output_file=test_output_file,
+        output_file=test_output_file1,
     )
 
-    test_df = pd.read_csv(test_output_file)
+    test_df = pd.read_csv(test_output_file1)
     pd.testing.assert_frame_equal(test_df, expected_result)
 
 
@@ -307,3 +308,32 @@ def test_custom_objectnumber_feature():
     expected_result = expected_result.astype(dtype_convert_dict)
 
     assert aggregate_result.equals(expected_result)
+
+
+def test_output_type():
+    """
+    Testing aggregate pycytominer function
+    """
+    # dictionary with the output name associated with the file type
+    output_dict = {"csv": test_output_file1, "parquet": test_output_file2}
+
+    # test both output types available with output function
+    for _type, outname in output_dict.items():
+        # Test output
+        aggregate(
+            population_df=data_df,
+            strata=["g"],
+            features="infer",
+            operation="median",
+            compute_object_count=True,
+            output_file=outname,
+            output_type=_type,
+        )
+
+    # read files in with pandas
+    csv_df = pd.read_csv(test_output_file1)
+    parquet_df = pd.read_parquet(test_output_file2)
+
+    # check to make sure the files were read in corrrectly as a pd.Dataframe
+    assert type(csv_df) == pd.DataFrame
+    assert type(parquet_df) == pd.DataFrame

--- a/pycytominer/tests/test_aggregate.py
+++ b/pycytominer/tests/test_aggregate.py
@@ -10,8 +10,8 @@ from pycytominer.cyto_utils import infer_cp_features
 tmpdir = tempfile.gettempdir()
 
 # Setup a testing file
-test_output_file1 = os.path.join(tmpdir, "test.csv")
-test_output_file2 = os.path.join(tmpdir, "test.parquet")
+test_output_file_csv = os.path.join(tmpdir, "test.csv")
+test_output_file_parquet = os.path.join(tmpdir, "test.parquet")
 
 # Build data to use in tests
 data_df = pd.concat(
@@ -74,10 +74,10 @@ def test_aggregate_median_allvar():
         strata=["g"],
         features="infer",
         operation="median",
-        output_file=test_output_file1,
+        output_file=test_output_file_csv,
     )
 
-    test_df = pd.read_csv(test_output_file1)
+    test_df = pd.read_csv(test_output_file_csv)
     pd.testing.assert_frame_equal(test_df, expected_result)
 
 
@@ -220,10 +220,10 @@ def test_aggregate_compute_object_count():
         features="infer",
         operation="median",
         compute_object_count=True,
-        output_file=test_output_file1,
+        output_file=test_output_file_csv,
     )
 
-    test_df = pd.read_csv(test_output_file1)
+    test_df = pd.read_csv(test_output_file_csv)
     pd.testing.assert_frame_equal(test_df, expected_result)
 
 
@@ -315,7 +315,7 @@ def test_output_type():
     Testing aggregate pycytominer function
     """
     # dictionary with the output name associated with the file type
-    output_dict = {"csv": test_output_file1, "parquet": test_output_file2}
+    output_dict = {"csv": test_output_file_csv, "parquet": test_output_file_parquet}
 
     # test both output types available with output function
     for _type, outname in output_dict.items():
@@ -331,9 +331,12 @@ def test_output_type():
         )
 
     # read files in with pandas
-    csv_df = pd.read_csv(test_output_file1)
-    parquet_df = pd.read_parquet(test_output_file2)
+    csv_df = pd.read_csv(test_output_file_csv)
+    parquet_df = pd.read_parquet(test_output_file_parquet)
 
     # check to make sure the files were read in corrrectly as a pd.Dataframe
     assert type(csv_df) == pd.DataFrame
     assert type(parquet_df) == pd.DataFrame
+
+    # check to make sure both dataframes are the same regardless of the output_type
+    pd.testing.assert_frame_equal(csv_df, parquet_df)

--- a/pycytominer/tests/test_annotate.py
+++ b/pycytominer/tests/test_annotate.py
@@ -11,7 +11,8 @@ random.seed(123)
 TMPDIR = tempfile.gettempdir()
 
 # Setup a testing file
-OUTPUT_FILE = pathlib.Path(f"{TMPDIR}/test.csv")
+OUTPUT_FILE1 = pathlib.Path(f"{TMPDIR}/test.csv")
+OUTPUT_FILE2 = pathlib.Path(f"{TMPDIR}/test.parquet")
 
 # Build data to use in tests
 DATA_DF = pd.concat(
@@ -142,7 +143,7 @@ def test_annotate_output():
         platemap=PLATEMAP_DF,
         join_on=["well_position", "Metadata_Well"],
         add_metadata_id_to_platemap=False,
-        output_file=OUTPUT_FILE,
+        output_file=OUTPUT_FILE1,
     )
 
     result = annotate(
@@ -152,7 +153,7 @@ def test_annotate_output():
         add_metadata_id_to_platemap=False,
         output_file=None,
     )
-    expected_result = pd.read_csv(OUTPUT_FILE)
+    expected_result = pd.read_csv(OUTPUT_FILE1)
 
     pd.testing.assert_frame_equal(result, expected_result)
 
@@ -177,3 +178,27 @@ def test_annotate_output_compress():
     )
     expected_result = pd.read_csv(compress_file)
     pd.testing.assert_frame_equal(result, expected_result)
+
+
+def test_output_type():
+    # dictionary with the output name associated with the file type
+    output_dict = {"csv": OUTPUT_FILE1, "parquet": OUTPUT_FILE2}
+
+    # test both output types available with output function
+    for _type, outname in output_dict.items():
+        # Test output
+        annotate(
+            profiles=DATA_DF,
+            platemap=PLATEMAP_DF,
+            join_on=["Metadata_well_position", "Metadata_Well"],
+            output_file=outname,
+            output_type=_type,
+        )
+
+    # read files in with pandas
+    csv_df = pd.read_csv(OUTPUT_FILE1)
+    parquet_df = pd.read_parquet(OUTPUT_FILE2)
+
+    # check to make sure the files were read in corrrectly as a pd.Dataframe
+    assert type(csv_df) == pd.DataFrame
+    assert type(parquet_df) == pd.DataFrame

--- a/pycytominer/tests/test_annotate.py
+++ b/pycytominer/tests/test_annotate.py
@@ -11,8 +11,8 @@ random.seed(123)
 TMPDIR = tempfile.gettempdir()
 
 # Setup a testing file
-OUTPUT_FILE1 = pathlib.Path(f"{TMPDIR}/test.csv")
-OUTPUT_FILE2 = pathlib.Path(f"{TMPDIR}/test.parquet")
+OUTPUT_FILE_CSV = pathlib.Path(f"{TMPDIR}/test.csv")
+OUTPUT_FILE_PARQUET = pathlib.Path(f"{TMPDIR}/test.parquet")
 
 # Build data to use in tests
 DATA_DF = pd.concat(
@@ -143,7 +143,7 @@ def test_annotate_output():
         platemap=PLATEMAP_DF,
         join_on=["well_position", "Metadata_Well"],
         add_metadata_id_to_platemap=False,
-        output_file=OUTPUT_FILE1,
+        output_file=OUTPUT_FILE_CSV,
     )
 
     result = annotate(
@@ -153,7 +153,7 @@ def test_annotate_output():
         add_metadata_id_to_platemap=False,
         output_file=None,
     )
-    expected_result = pd.read_csv(OUTPUT_FILE1)
+    expected_result = pd.read_csv(OUTPUT_FILE_CSV)
 
     pd.testing.assert_frame_equal(result, expected_result)
 
@@ -182,7 +182,7 @@ def test_annotate_output_compress():
 
 def test_output_type():
     # dictionary with the output name associated with the file type
-    output_dict = {"csv": OUTPUT_FILE1, "parquet": OUTPUT_FILE2}
+    output_dict = {"csv": OUTPUT_FILE_CSV, "parquet": OUTPUT_FILE_PARQUET}
 
     # test both output types available with output function
     for _type, outname in output_dict.items():
@@ -196,9 +196,12 @@ def test_output_type():
         )
 
     # read files in with pandas
-    csv_df = pd.read_csv(OUTPUT_FILE1)
-    parquet_df = pd.read_parquet(OUTPUT_FILE2)
+    csv_df = pd.read_csv(OUTPUT_FILE_CSV)
+    parquet_df = pd.read_parquet(OUTPUT_FILE_PARQUET)
 
     # check to make sure the files were read in corrrectly as a pd.Dataframe
     assert type(csv_df) == pd.DataFrame
     assert type(parquet_df) == pd.DataFrame
+
+    # check to make sure both dataframes are the same regardless of the output_type
+    pd.testing.assert_frame_equal(csv_df, parquet_df)

--- a/pycytominer/tests/test_consensus.py
+++ b/pycytominer/tests/test_consensus.py
@@ -9,7 +9,8 @@ random.seed(123)
 
 # Get temporary directory
 tmpdir = tempfile.gettempdir()
-output_test_file = os.path.join(tmpdir, "test.csv")
+output_test_file1 = os.path.join(tmpdir, "test.csv")
+output_test_file2 = os.path.join(tmpdir, "test.parquet")
 input_test_file = os.path.join(tmpdir, "example_input.csv")
 
 # Set example data
@@ -47,10 +48,10 @@ def test_consensus_aggregate():
         data_df,
         replicate_columns="Metadata_treatment",
         operation="mean",
-        output_file=output_test_file,
+        output_file=output_test_file1,
     )
 
-    pd.testing.assert_frame_equal(mean_df, pd.read_csv(output_test_file))
+    pd.testing.assert_frame_equal(mean_df, pd.read_csv(output_test_file1))
 
     median_df = consensus(
         data_df, replicate_columns="Metadata_treatment", operation="median"
@@ -95,7 +96,31 @@ def test_consensus_modz():
         data_df,
         replicate_columns="Metadata_treatment",
         operation="mean",
-        output_file=output_test_file,
+        output_file=output_test_file1,
     )
 
-    pd.testing.assert_frame_equal(modz_df, pd.read_csv(output_test_file))
+    pd.testing.assert_frame_equal(modz_df, pd.read_csv(output_test_file1))
+
+
+def test_output_type():
+    # dictionary with the output name associated with the file type
+    output_dict = {"csv": output_test_file1, "parquet": output_test_file2}
+
+    # test both output types available with output function
+    for _type, outname in output_dict.items():
+        # Test output
+        consensus(
+            data_df,
+            replicate_columns="Metadata_treatment",
+            operation="mean",
+            output_file=outname,
+            output_type=_type,
+        )
+
+    # read files in with pandas
+    csv_df = pd.read_csv(output_test_file1)
+    parquet_df = pd.read_parquet(output_test_file2)
+
+    # check to make sure the files were read in corrrectly as a pd.Dataframe
+    assert type(csv_df) == pd.DataFrame
+    assert type(parquet_df) == pd.DataFrame

--- a/pycytominer/tests/test_consensus.py
+++ b/pycytominer/tests/test_consensus.py
@@ -9,8 +9,8 @@ random.seed(123)
 
 # Get temporary directory
 tmpdir = tempfile.gettempdir()
-output_test_file1 = os.path.join(tmpdir, "test.csv")
-output_test_file2 = os.path.join(tmpdir, "test.parquet")
+output_test_file_csv = os.path.join(tmpdir, "test.csv")
+output_test_file_parquet = os.path.join(tmpdir, "test.parquet")
 input_test_file = os.path.join(tmpdir, "example_input.csv")
 
 # Set example data
@@ -48,10 +48,10 @@ def test_consensus_aggregate():
         data_df,
         replicate_columns="Metadata_treatment",
         operation="mean",
-        output_file=output_test_file1,
+        output_file=output_test_file_csv,
     )
 
-    pd.testing.assert_frame_equal(mean_df, pd.read_csv(output_test_file1))
+    pd.testing.assert_frame_equal(mean_df, pd.read_csv(output_test_file_csv))
 
     median_df = consensus(
         data_df, replicate_columns="Metadata_treatment", operation="median"
@@ -96,15 +96,15 @@ def test_consensus_modz():
         data_df,
         replicate_columns="Metadata_treatment",
         operation="mean",
-        output_file=output_test_file1,
+        output_file=output_test_file_csv,
     )
 
-    pd.testing.assert_frame_equal(modz_df, pd.read_csv(output_test_file1))
+    pd.testing.assert_frame_equal(modz_df, pd.read_csv(output_test_file_csv))
 
 
 def test_output_type():
     # dictionary with the output name associated with the file type
-    output_dict = {"csv": output_test_file1, "parquet": output_test_file2}
+    output_dict = {"csv": output_test_file_csv, "parquet": output_test_file_parquet}
 
     # test both output types available with output function
     for _type, outname in output_dict.items():
@@ -118,9 +118,12 @@ def test_output_type():
         )
 
     # read files in with pandas
-    csv_df = pd.read_csv(output_test_file1)
-    parquet_df = pd.read_parquet(output_test_file2)
+    csv_df = pd.read_csv(output_test_file_csv)
+    parquet_df = pd.read_parquet(output_test_file_parquet)
 
     # check to make sure the files were read in corrrectly as a pd.Dataframe
     assert type(csv_df) == pd.DataFrame
     assert type(parquet_df) == pd.DataFrame
+
+    # check to make sure both dataframes are the same regardless of the output_type
+    pd.testing.assert_frame_equal(csv_df, parquet_df)

--- a/pycytominer/tests/test_feature_select.py
+++ b/pycytominer/tests/test_feature_select.py
@@ -11,6 +11,10 @@ random.seed(123)
 # Get temporary directory
 tmpdir = tempfile.gettempdir()
 
+# Setup testing files
+test_output_file1 = os.path.join(tmpdir, "test.csv")
+test_output_file2 = os.path.join(tmpdir, "test.parquet")
+
 data_df = pd.DataFrame(
     {
         "x": [1, 3, 8, 5, 2, 2],
@@ -441,3 +445,30 @@ def test_feature_select_drop_outlier():
         outlier_cutoff=15,
     )
     pd.testing.assert_frame_equal(result, data_outlier_df)
+
+
+def test_output_type():
+    """
+    Testing feature_select pycytominer function
+    """
+    # dictionary with the output name associated with the file type
+    output_dict = {"csv": test_output_file1, "parquet": test_output_file2}
+
+    # test both output types available with output function
+    for _type, outname in output_dict.items():
+        # Test output
+        feature_select(
+            data_df,
+            features=data_df.columns.tolist(),
+            operation="blocklist",
+            output_file=outname,
+            output_type=_type,
+        )
+
+    # read files in with pandas
+    csv_df = pd.read_csv(test_output_file1)
+    parquet_df = pd.read_parquet(test_output_file2)
+
+    # check to make sure the files were read in corrrectly as a pd.Dataframe
+    assert type(csv_df) == pd.DataFrame
+    assert type(parquet_df) == pd.DataFrame

--- a/pycytominer/tests/test_feature_select.py
+++ b/pycytominer/tests/test_feature_select.py
@@ -12,8 +12,8 @@ random.seed(123)
 tmpdir = tempfile.gettempdir()
 
 # Setup testing files
-test_output_file1 = os.path.join(tmpdir, "test.csv")
-test_output_file2 = os.path.join(tmpdir, "test.parquet")
+output_test_file_csv = os.path.join(tmpdir, "test.csv")
+output_test_file_parquet = os.path.join(tmpdir, "test.parquet")
 
 data_df = pd.DataFrame(
     {
@@ -452,7 +452,7 @@ def test_output_type():
     Testing feature_select pycytominer function
     """
     # dictionary with the output name associated with the file type
-    output_dict = {"csv": test_output_file1, "parquet": test_output_file2}
+    output_dict = {"csv": output_test_file_csv, "parquet": output_test_file_parquet}
 
     # test both output types available with output function
     for _type, outname in output_dict.items():
@@ -466,9 +466,12 @@ def test_output_type():
         )
 
     # read files in with pandas
-    csv_df = pd.read_csv(test_output_file1)
-    parquet_df = pd.read_parquet(test_output_file2)
+    csv_df = pd.read_csv(output_test_file_csv)
+    parquet_df = pd.read_parquet(output_test_file_parquet)
 
     # check to make sure the files were read in corrrectly as a pd.Dataframe
     assert type(csv_df) == pd.DataFrame
     assert type(parquet_df) == pd.DataFrame
+
+    # check to make sure both dataframes are the same regardless of the output_type
+    pd.testing.assert_frame_equal(csv_df, parquet_df)

--- a/pycytominer/tests/test_normalize.py
+++ b/pycytominer/tests/test_normalize.py
@@ -11,8 +11,8 @@ random.seed(123)
 tmpdir = tempfile.gettempdir()
 
 # Setup testing files
-test_output_file1 = os.path.join(tmpdir, "test.csv")
-test_output_file2 = os.path.join(tmpdir, "test.parquet")
+output_test_file_csv = os.path.join(tmpdir, "test.csv")
+output_test_file_parquet = os.path.join(tmpdir, "test.parquet")
 
 # Build data to use in tests
 data_df = pd.DataFrame(
@@ -533,10 +533,10 @@ def test_spherize_epsilon():
 
 def test_output_type():
     """
-    Testing normalize pycytominer function
+    Testing normalize pycytominer function with output
     """
     # dictionary with the output name associated with the file type
-    output_dict = {"csv": test_output_file1, "parquet": test_output_file2}
+    output_dict = {"csv": output_test_file_csv, "parquet": output_test_file_parquet}
 
     # test both output types available with output function
     for _type, outname in output_dict.items():
@@ -552,9 +552,12 @@ def test_output_type():
         )
 
     # read files in with pandas
-    csv_df = pd.read_csv(test_output_file1)
-    parquet_df = pd.read_parquet(test_output_file2)
+    csv_df = pd.read_csv(output_test_file_csv)
+    parquet_df = pd.read_parquet(output_test_file_parquet)
 
     # check to make sure the files were read in corrrectly as a pd.Dataframe
     assert type(csv_df) == pd.DataFrame
     assert type(parquet_df) == pd.DataFrame
+
+    # check to make sure both dataframes are the same regardless of the output_type
+    pd.testing.assert_frame_equal(csv_df, parquet_df)

--- a/pycytominer/tests/test_normalize.py
+++ b/pycytominer/tests/test_normalize.py
@@ -10,6 +10,10 @@ random.seed(123)
 # Get temporary directory
 tmpdir = tempfile.gettempdir()
 
+# Setup testing files
+test_output_file1 = os.path.join(tmpdir, "test.csv")
+test_output_file2 = os.path.join(tmpdir, "test.parquet")
+
 # Build data to use in tests
 data_df = pd.DataFrame(
     {
@@ -525,3 +529,32 @@ def test_spherize_epsilon():
             assert off_diag_sum > 0
         else:
             assert off_diag_sum == 0
+
+
+def test_output_type():
+    """
+    Testing normalize pycytominer function
+    """
+    # dictionary with the output name associated with the file type
+    output_dict = {"csv": test_output_file1, "parquet": test_output_file2}
+
+    # test both output types available with output function
+    for _type, outname in output_dict.items():
+        # Test output
+        normalize(
+            profiles=data_file,
+            features=["x", "y", "z", "zz"],
+            meta_features="infer",
+            samples="all",
+            method="standardize",
+            output_file=outname,
+            output_type=_type,
+        )
+
+    # read files in with pandas
+    csv_df = pd.read_csv(test_output_file1)
+    parquet_df = pd.read_parquet(test_output_file2)
+
+    # check to make sure the files were read in corrrectly as a pd.Dataframe
+    assert type(csv_df) == pd.DataFrame
+    assert type(parquet_df) == pd.DataFrame


### PR DESCRIPTION
_modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_

# Description

This PR serves as a solution to issue #306 and allows for a user that uses the major functions to specify the output file type instead of only being able to output files as CSV or CSV compressed. A user would be able to utilize the `output` functions ability to output files as `parquet`. 

## What is the nature of your change?

- [X] Bug fix (fixes an issue).
- [X] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have deleted all non-relevant text in this pull request template.
