### PR TITLE
Remove `master` branch references after migrating to `main`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-      # Temporary inclusion of master branch during default branch name transition
-      - master
   pull_request:
     branches:
       - main
-      # Temporary inclusion of master branch during default branch name transition
-      - master
 
 jobs:
   run:

--- a/.github/workflows/pre-commit-ci.yml
+++ b/.github/workflows/pre-commit-ci.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     branches:
       - main
-      # Temporary inclusion of master branch during default branch name transition
-      - master
 jobs:
   pre-commit-ci:
     name: Run pre-commit checks on changed files

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,13 +7,9 @@ on:
   push:
     branches:
       - main
-      # Temporary inclusion of master branch during default branch name transition
-      - master
   pull_request:
     branches:
       - main
-      # Temporary inclusion of master branch during default branch name transition
-      - master
 
 jobs:
   build:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. pycytominer documentation master file, created by
+.. pycytominer documentation main file, created by
    sphinx-quickstart on Fri Feb 19 14:44:29 2021.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.


### PR DESCRIPTION
Fixes #318

# Description

As part of the transition to more inclusive language this removes references to the `master` branches that were previously present in the codebase. 

## What is the nature of your change?

- [X] Bug fix (fixes an issue).

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have deleted all non-relevant text in this pull request template.
