### PR TITLE
fix(docs): add dynamic versioning to docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,9 @@ build:
   tools:
     python: "3.11"
   jobs:
+    post_checkout:
+      # Full history is required for dunamai to calculate the version
+      - git fetch --unshallow || true
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 import pathlib
-import yaml
+import dunamai
 from datetime import date
 
 sys.path.insert(0, os.path.abspath(".."))
@@ -28,9 +28,9 @@ copyright = "Copyright 2019 - {date} {author}".format(
     date=date.today().year, author=author
 )
 
-# The version from CITATION.cff is used to set the version of the package
-cff_path = pathlib.Path("..") / "CITATION.cff"
-version = yaml.safe_load(cff_path.read_text())["version"]
+# Get the version from dunamai (the backend of poetry-dynamic-versioning)
+auto_version = dunamai.Version.from_git()
+version = auto_version.serialize()
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -928,6 +928,20 @@ files = [
 ]
 
 [[package]]
+name = "dunamai"
+version = "1.19.0"
+description = "Dynamic version generation"
+optional = false
+python-versions = ">=3.5,<4.0"
+files = [
+    {file = "dunamai-1.19.0-py3-none-any.whl", hash = "sha256:1ed948676bbf0812bfaafe315a134634f8d6eb67138513c75aa66e747404b9c6"},
+    {file = "dunamai-1.19.0.tar.gz", hash = "sha256:6ad99ae34f7cd290550a2ef1305d2e0292e6e6b5b1b830dfc07ceb7fd35fec09"},
+]
+
+[package.dependencies]
+packaging = ">=20.9"
+
+[[package]]
 name = "entrypoints"
 version = "0.4"
 description = "Discover and load entry points from installed packages."
@@ -2157,8 +2171,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3855,5 +3869,5 @@ collate = ["cytominer-database"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8"
-content-hash = "8cf2b95830b6f167fe5bf383567a41761649b500cd6a4830753f8904578b995d"
+python-versions = ">=3.8,<4.0"
+content-hash = "190d54fe1dc6ec399bb66ab4777376b2b0ebbacc04a8ada0ee39350d93c5e72d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ homepage = "https://pycytominer.readthedocs.io/"
 repository = "https://github.com/cytomining/pycytominer"
 
 [tool.poetry.dependencies]
-python          = ">=3.8"
+python          = ">=3.8,<4.0"
 numpy           = ">=1.16.5"
 scipy           = ">=1.5"
 pandas          = ">=1.2.0"
@@ -85,6 +85,7 @@ m2r2 = "^0.3.3.post2"
 furo = "^2023.9.10"
 mock = "^5.1.0"
 autodoc = "^0.5.0"
+dunamai = "^1.19.0"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
# Description

This change will ensure that RTD docs in the `latest` section will more correctly display a version such as `1.0.0.post7.dev0+g29045e8` when the main branch contains 7 un-released commits instead of continuing to display `1.0.0`. 

This introduces the `dunamai` docs dependency which is already an indirect dependency for our build process. `poetry-dynamic-versioning` uses `dunamai` to calculate the appropriate version strings. 

Closes #352

## What is the nature of your change?

- [x] Bug fix (fixes an issue).

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.


<!-- readthedocs-preview pycytominer start -->
----
:books: Documentation preview :books:: https://pycytominer--353.org.readthedocs.build/en/353/

<!-- readthedocs-preview pycytominer end -->