### PR TITLE
bump: version 1.0.0 → 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.0.1 (2023-11-07)
+
+[Detailed Release Notes](https://github.com/cytomining/pycytominer/releases/tag/v1.0.1)
+
+### Fix
+
+- **docs**: add dynamic versioning to docs build
+- **collate**: move optional dep import to function
+
 ## v1.0.0 (2023-10-29)
 
 [Detailed Release Notes](https://github.com/cytomining/pycytominer/releases/tag/v1.0.0)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -67,6 +67,6 @@ authors:
     orcid: https://orcid.org/0000-0002-0503-9348
 title: "Reproducible processing of image-based profiling representations with Pycytominer"
 # This version is updated using `cz bump` command
-version: "1.0.0"
+version: "1.0.1"
 license: BSD 3-Clause License
 repository-code: "https://github.com/cytomining/pycytominer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ files = ["pycytominer/__about__.py"]
 
 [tool.commitizen]
 # This version is used for changelog tracking and is updated using `cz bump`
-version = "1.0.0"
+version = "1.0.1"
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "pep440"


### PR DESCRIPTION
## v1.0.1 (2023-11-07)

### Fix

- **docs**: add dynamic versioning to docs build
- **collate**: move optional dep import to function