### PR TITLE
fix: add workspaceDir to git safe directories for devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   },
   // This command is kept outside of the postCreateCommand script because we
   // don't want to include a privileged command in the manual setup process.
-  "onCreateCommand": "sudo /usr/local/py-utils/bin/poetry self add \"poetry-dynamic-versioning[plugin]\"",
+  "onCreateCommand": "sudo /usr/local/py-utils/bin/poetry self add \"poetry-dynamic-versioning[plugin]\" && git config --global --add safe.directory ${workspaceFolder}",
   // This postCreateCommand script is also referenced for manual dev setup.
   "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
   // Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   },
   // This command is kept outside of the postCreateCommand script because we
   // don't want to include a privileged command in the manual setup process.
-  "onCreateCommand": "sudo /usr/local/py-utils/bin/poetry self add \"poetry-dynamic-versioning[plugin]\" && git config --global --add safe.directory ${workspaceFolder}",
+  "onCreateCommand": "sudo /usr/local/py-utils/bin/poetry self add \"poetry-dynamic-versioning[plugin]\" && git config --global --add safe.directory ${containerWorkspaceFolder}",
   // This postCreateCommand script is also referenced for manual dev setup.
   "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
   // Configure tool-specific properties.

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,8 +1,4 @@
 #! /usr/bin/env bash
-# Specify current directory as safe to avoid the error:
-#  Detected Git repository, but failed because of dubious ownership
-# See https://sam.hooke.me/note/2023/08/poetry-fixing-dubious-ownership-error/
-git config --global --add safe.directory $(pwd)
 # PDV will already have been installed in a devcontainer, but is 
 # re-included here for the benefit of manual dev environments.
 poetry self add "poetry-dynamic-versioning[plugin]"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,4 +1,8 @@
 #! /usr/bin/env bash
+# Specify current directory as safe to avoid the error:
+#  Detected Git repository, but failed because of dubious ownership
+# See https://sam.hooke.me/note/2023/08/poetry-fixing-dubious-ownership-error/
+git config --global --add safe.directory $(pwd)
 # PDV will already have been installed in a devcontainer, but is 
 # re-included here for the benefit of manual dev environments.
 poetry self add "poetry-dynamic-versioning[plugin]"


### PR DESCRIPTION
# Description

When creating the container via VSCode v1.87.2 on my local OSX 14.2.1 (23C71), I got the error `Detected Git repository, but failed because of dubious ownership`

I found a fix here: https://sam.hooke.me/note/2023/08/poetry-fixing-dubious-ownership-error/

## What is the nature of your change?

- [x] Bug fix (fixes an issue).

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Not applicable: I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Not applicable: I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
