### PR TITLE
refactor(pandas): enable copy_on_write for Pandas

### DIFF
--- a/pycytominer/__config__.py
+++ b/pycytominer/__config__.py
@@ -1,0 +1,9 @@
+"""
+Module used for pycytominer configuration details.
+"""
+
+import pandas as pd
+
+# configure pandas copy_on_write for 3.0.0 requirements
+# see: https://pandas.pydata.org/pandas-docs/version/2.2.0/whatsnew/v2.2.0.html#copy-on-write
+pd.options.mode.copy_on_write = True

--- a/pycytominer/__init__.py
+++ b/pycytominer/__init__.py
@@ -1,4 +1,4 @@
-from pycytominer import __about__
+from pycytominer import __about__, __config__
 
 from .aggregate import aggregate
 from .annotate import annotate

--- a/pycytominer/cyto_utils/modz.py
+++ b/pycytominer/cyto_utils/modz.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from pycytominer.cyto_utils.util import (
     get_pairwise_correlation,
     check_correlation_method,
@@ -43,9 +44,17 @@ def modz_base(population_df, method="spearman", min_weight=0.01, precision=4):
     # Round correlation results
     pair_df = pair_df.round(precision)
 
+    # create a copy of cor_df values for use with np.fill_diagonal
+    cor_df_values = cor_df.values.copy()
+
     # Step 2: Identify sample weights
     # Fill diagonal of correlation_matrix with np.nan
-    np.fill_diagonal(cor_df.values, np.nan)
+    np.fill_diagonal(cor_df_values, np.nan)
+
+    # reconstitute the changed data as a new dataframe to avoid read-only behavior
+    cor_df = pd.DataFrame(
+        data=cor_df_values, index=cor_df.index, columns=cor_df.columns
+    )
 
     # Remove negative values
     cor_df = cor_df.clip(lower=0)


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

This PR adds a configuration module and setting for Pandas (`copy_on_write`) which will eventually be turned on by default in Pandas >= 3.0.0 . Besides proactively avoiding issues with upgrades to Pandas, there are also possible performance benefits to doing this early (as per [Pandas documentation on `copy_on_write`](https://pandas.pydata.org/docs/user_guide/copy_on_write.html)). I made these changes based on tests which were failing and noted in #366 .

After making this change, there are new test warnings concerning `PerformanceWarning: DataFrame is highly fragmented.` which may be worth investigating as part of this issue or possibly a new issue.

Closes #366 

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
