### PR TITLE
refactor(pd): avoid dataframe fragmentation in agg

### DIFF
--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -2,6 +2,8 @@
 Aggregate profiles based on given grouping variables.
 """
 
+from typing import Any, Dict, List, Optional, Union
+
 import numpy as np
 import pandas as pd
 
@@ -13,18 +15,18 @@ from pycytominer.cyto_utils import (
 
 
 def aggregate(
-    population_df,
-    strata=["Metadata_Plate", "Metadata_Well"],
-    features="infer",
-    operation="median",
-    output_file=None,
-    output_type="csv",
-    compute_object_count=False,
-    object_feature="Metadata_ObjectNumber",
-    subset_data_df=None,
-    compression_options=None,
-    float_format=None,
-):
+    population_df: pd.DataFrame,
+    strata: List[str] = ["Metadata_Plate", "Metadata_Well"],
+    features: Union[List[str], str] = "infer",
+    operation: str = "median",
+    output_file: Optional[str] = None,
+    output_type: Optional[str] = "csv",
+    compute_object_count: bool = False,
+    object_feature: str = "Metadata_ObjectNumber",
+    subset_data_df: Optional[pd.DataFrame] = None,
+    compression_options: Optional[Union[str, Dict[str, Any]]] = None,
+    float_format: Optional[str] = None,
+) -> Optional[pd.DataFrame]:
     """Combine population dataframe variables by strata groups using given operation.
 
     Parameters
@@ -76,13 +78,13 @@ def aggregate(
         ).reindex(population_df.columns, axis="columns")
 
     # Subset dataframe to only specified variables if provided
-    strata_df = population_df.loc[:, strata]
+    strata_df = population_df[strata]
 
     # Only extract single object column in preparation for count
     if compute_object_count:
-        count_object_df = population_df.loc[:, np.union1d(strata, [object_feature])]
         count_object_df = (
-            count_object_df.groupby(strata)[object_feature]
+            population_df.loc[:, np.union1d(strata, [object_feature])]
+            .groupby(strata)[object_feature]
             .count()
             .reset_index()
             .rename(columns={f"{object_feature}": "Metadata_Object_Count"})
@@ -90,13 +92,10 @@ def aggregate(
 
     if features == "infer":
         features = infer_cp_features(population_df)
-        population_df = population_df.loc[:, features]
-    else:
-        population_df = population_df.loc[:, features]
+    population_df = population_df[features]
 
     # Fix dtype of input features (they should all be floats!)
-    convert_dict = {x: float for x in features}
-    population_df = population_df.astype(convert_dict)
+    population_df = population_df.astype(float)
 
     # Merge back metadata used to aggregate by
     population_df = pd.concat([strata_df, population_df], axis="columns")
@@ -114,9 +113,12 @@ def aggregate(
         population_df = count_object_df.merge(population_df, on=strata, how="right")
 
     # Aggregated image number and object number do not make sense
-    for col in ["ImageNumber", "ObjectNumber"]:
-        if col in population_df.columns:
-            population_df = population_df.drop([col], axis="columns")
+    if columns_to_drop := [
+        column
+        for column in population_df.columns
+        if column in ["ImageNumber", "ObjectNumber"]
+    ]:
+        population_df = population_df.drop([columns_to_drop], axis="columns")
 
     if output_file is not None:
         output(
@@ -128,5 +130,3 @@ def aggregate(
         )
     else:
         return population_df
-
-    return population_df


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

This PR addresses #404 Pandas DataFrame fragmentation warnings from `aggregate`. Generally I also took time to add type hints and focus on performance of the function throughout. It appeared that the fragmentation warnings were somewhat related to the `DataFrame.loc[...]` usage. It seemed that once I addressed these that additional fragmentation warnings from other modules went away.

I noticed that test `tests/test_cyto_utils/test_DeepProfiler_processing.py::test_aggregate` ran with a lower time duration after this change, possibly due to the reduction of warnings being emitted. This was a loose measurement on an M1 Mac with Python 3.11.9.
- Before: ~37 seconds
- After: ~7 seconds

As a heads up, we may run into #406, which is unrelated to the changes here.

Closes #404

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
