### PR TITLE
bug(compartments): avoid lowercase compartment strings

### DIFF
--- a/pycytominer/cyto_utils/features.py
+++ b/pycytominer/cyto_utils/features.py
@@ -4,6 +4,7 @@ Utility function to manipulate cell profiler features
 
 import os
 import pandas as pd
+from typing import Union, List
 
 blocklist_file = os.path.join(
     os.path.dirname(__file__), "..", "data", "blocklist_features.txt"
@@ -185,7 +186,9 @@ def drop_outlier_features(
     return outlier_features
 
 
-def convert_compartment_format_to_list(compartments):
+def convert_compartment_format_to_list(
+    compartments: Union[List[str], str],
+) -> List[str]:
     """Converts compartment to a list.
 
     Parameters
@@ -199,9 +202,4 @@ def convert_compartment_format_to_list(compartments):
         List of Cell Painting compartments.
     """
 
-    if isinstance(compartments, list):
-        compartments = [x.lower() for x in compartments]
-    elif isinstance(compartments, str):
-        compartments = [compartments.lower()]
-
-    return compartments
+    return compartments if isinstance(compartments, list) else [compartments]

--- a/tests/test_cyto_utils/test_features_util.py
+++ b/tests/test_cyto_utils/test_features_util.py
@@ -2,8 +2,13 @@ from pycytominer.cyto_utils.features import convert_compartment_format_to_list
 
 
 def test_convert_compartment_format_to_list():
-    compartments = convert_compartment_format_to_list(["cells", "CYTOplasm", "nuclei"])
-    assert compartments == ["cells", "cytoplasm", "nuclei"]
+    compartments = convert_compartment_format_to_list([
+        "cells",
+        "CYTOplasm",
+        "nuclei",
+        "MyoD",
+    ])
+    assert compartments == ["cells", "CYTOplasm", "nuclei", "MyoD"]
 
     compartments = convert_compartment_format_to_list("FoO")
-    assert compartments == ["foo"]
+    assert compartments == ["FoO"]

--- a/tests/test_cyto_utils/test_util.py
+++ b/tests/test_cyto_utils/test_util.py
@@ -43,31 +43,35 @@ def test_check_compartments():
 
 
 def test_check_compartments_not_valid():
-    warn_expected_string = "Non-canonical compartment detected: something"
     warnings.simplefilter("always")
     with warnings.catch_warnings(record=True) as w:
         not_valid = ["SOMETHING"]
         check_compartments(not_valid)
     assert issubclass(w[-1].category, UserWarning)
-    assert warn_expected_string in str(w[-1].message)
+    assert "Non-canonical compartment detected: SOMETHING" in str(w[-1].message)
 
     with warnings.catch_warnings(record=True) as w:
         not_valid = "SOMETHING"  # Also works with strings
         check_compartments(not_valid)
     assert issubclass(w[-1].category, UserWarning)
-    assert warn_expected_string in str(w[-1].message)
+    assert "Non-canonical compartment detected: SOMETHING" in str(w[-1].message)
 
     with warnings.catch_warnings(record=True) as w:
         not_valid = ["CelLs", "CytopLasM", "SOMETHING"]
         check_compartments(not_valid)
     assert issubclass(w[-1].category, UserWarning)
-    assert warn_expected_string in str(w[-1].message)
+    assert "Non-canonical compartment detected: CelLs, CytopLasM, SOMETHING" in str(
+        w[-1].message
+    )
 
     with warnings.catch_warnings(record=True) as w:
         not_valid = ["CelLs", "CytopLasM", "SOMETHING", "NOTHING"]
         check_compartments(not_valid)
     assert issubclass(w[-1].category, UserWarning)
-    assert f"{warn_expected_string}, nothing" in str(w[-1].message)
+    assert (
+        "Non-canonical compartment detected: CelLs, CytopLasM, SOMETHING, NOTHING"
+        in str(w[-1].message)
+    )
 
 
 def test_get_default_compartments():


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

This PR addresses #412 by updating `convert_compartment_format_to_list` to avoid lowercasing compartment name strings. As part of this work I had to update existing tests to allow them to pass. While I was updating materials I also added type hints to the function definition.

I believe new test warnings are emitted because of these changes.

Please don't hesitate to let me know if you have any questions. Thanks for any feedback!

Closes #412

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
