### PR TITLE
Add dark mode style color for contrast in docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,8 +16,9 @@ build:
       - poetry config virtualenvs.create false
     post_install:
       # Install dependencies with 'docs' dependency group
-      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --with dev,docs --all-extras
+      # (https://python-poetry.org/docs/managing-dependencies/#dependency-groups)
+      # and leverage READTHEDOCS_VIRTUALENV_PATH for environment.
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with dev,docs --all-extras
 
 sphinx:
   builder: html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,26 +55,28 @@ exclude_patterns = ["**tests**"]
 
 
 # -- Options for HTML output -------------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-pycytominer_hex = "#88239A"
+# The theme to use for HTML and HTML Help pages.
 # Furo theme options specified here: https://pradyunsg.me/furo/
 html_theme = "furo"
+
+# colors used for styling the HTML output in light or dark mode
+pycytominer_hex_light = "#88239A"
+pycytominer_hex_dark = "#CF72DF"
+
 # Furo theme option colors specified here:
 # https://github.com/pradyunsg/furo/blob/main/src/furo/assets/styles/variables/_colors.scss
 html_theme_options = {
     "light_css_variables": {
-        "color-brand-primary": pycytominer_hex,
-        "color-brand-content": pycytominer_hex,
-        "color-api-pre-name": pycytominer_hex,
-        "color-api-name": pycytominer_hex,
+        "color-brand-primary": pycytominer_hex_light,
+        "color-brand-content": pycytominer_hex_light,
+        "color-api-pre-name": pycytominer_hex_light,
+        "color-api-name": pycytominer_hex_light,
     },
     "dark_css_variables": {
-        "color-brand-primary": pycytominer_hex,
-        "color-brand-content": pycytominer_hex,
-        "color-api-pre-name": pycytominer_hex,
-        "color-api-name": pycytominer_hex,
+        "color-brand-primary": pycytominer_hex_dark,
+        "color-brand-content": pycytominer_hex_dark,
+        "color-api-pre-name": pycytominer_hex_dark,
+        "color-api-name": pycytominer_hex_dark,
     },
 }
 


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

This PR addresses #428 by allowing the documentation to use distinct colors for styling in light and dark modes. While I made these changes I also slightly reorganized the comments and code nearby for the Sphinx theme configuration.

Additionally, I noticed Read the Docs builds were failing, seemingly due to the environment not installing properly from Poetry. I added a small fix to `.readthedocs.yml` to try and re-enable builds which seems to have worked.

I manually tested the web accessibility of the color contrast using Lighthouse through the developer console in Chrome. Let me know if you think we should update the color to a different one based on the contrast or how it aligns with other styling.

Closes #428

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.


<!-- readthedocs-preview pycytominer start -->
----
📚 Documentation preview 📚: https://pycytominer--429.org.readthedocs.build/en/429/

<!-- readthedocs-preview pycytominer end -->