### PR TITLE
ci: exclude scipy, sqlachemy, pandas from groups updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          - "pandas"
+          - "scipy"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,4 @@ updates:
         exclude-patterns:
           - "pandas"
           - "scipy"
+          - "sqlalchemy"


### PR DESCRIPTION
# Description

The most recent dependabot groups PR [failed](https://github.com/cytomining/pycytominer/pull/466) due to changes in pandas. Due to the importance of pandas and scipy to the pycytominer codebase and a higher likelihood of breaking changes, I propose we separate them from the grouped updates. 

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
