### PR TITLE
ci(cache): use os with arch for cache naming

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -51,7 +51,7 @@ runs:
         path: |
           .cache
           pre-commit
-        key: cache|${{ runner.os }}|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+        key: cache|${{ runner.os }}|${{ runner.arch }}|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Cache venv
       # The cache key for the virtual environment is a hash of the
       # operating system, PY (see above), the pyproject.toml and
@@ -64,7 +64,7 @@ runs:
           .cache
           .venv
         key:
-          cache|${{ runner.os }}|${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{
+          cache|${{ runner.os }}|${{ runner.arch }}|${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{
           hashFiles('poetry.lock') }}
     - name: Setup poetry and poetry-dynamic-versioning
       shell: bash


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

This PR makes a slight change in how caching is performed within GitHub actions to include the OS arch in addition to name. I found that the cache key name appears to overlap sometimes which can cause problems for new venv builds (for example in #506 where MacOS 14 with Python 3.11 has troubles). I'd include the runner image nickname, e.g. `macos-14`, but this doesn't appear to be available within the [`runner` context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context). I  also tried making use of `$ImageOS` but this doesn't appear to be available on every image (and isn't very well documented).

Should be merged prior to #506  in order to address failing job.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
