### PR TITLE
Return output filepath when `output_file` is used by core functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,38 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.8"
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.11.9"
     hooks:
-      - id: ruff
+    -   id: ruff
         exclude: tutorials/nbconverted/
-      - id: ruff-format
+    -   id: ruff-format
         exclude: tutorials/nbconverted/
-  - repo: https://github.com/pre-commit/mirrors-prettier
+-   repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.1.0"
     hooks:
-      - id: prettier
-  - repo: https://github.com/python-poetry/poetry
+    -   id: prettier
+-   repo: https://github.com/python-poetry/poetry
     rev: "2.1.3"
     hooks:
-      - id: poetry-check
-  - repo: https://github.com/rhysd/actionlint
+    -   id: poetry-check
+-   repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:
-      - id: actionlint
-  - repo: https://github.com/hadolint/hadolint
+    -   id: actionlint
+-   repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:
-      - id: hadolint-docker
-  - repo: https://github.com/tox-dev/pyproject-fmt
+    -   id: hadolint-docker
+-   repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.5.1"
     hooks:
-      - id: pyproject-fmt
+    -   id: pyproject-fmt
     # validates CITATION.cff file formatting expectations
-  - repo: https://github.com/citation-file-format/cffconvert
+-   repo: https://github.com/citation-file-format/cffconvert
     rev: b6045d78aac9e02b039703b030588d54d53262ac
     hooks:
-      - id: validate-cff
-  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    -   id: validate-cff
+-   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: v0.7.0
     hooks:
-      - id: pre-commit-update
+    -   id: pre-commit-update
         args: ["--keep", "cffconvert"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,38 @@
 repos:
--   repo: https://github.com/astral-sh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.11.9"
     hooks:
-    -   id: ruff
+      - id: ruff
         exclude: tutorials/nbconverted/
-    -   id: ruff-format
+      - id: ruff-format
         exclude: tutorials/nbconverted/
--   repo: https://github.com/pre-commit/mirrors-prettier
+  - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.1.0"
     hooks:
-    -   id: prettier
--   repo: https://github.com/python-poetry/poetry
+      - id: prettier
+  - repo: https://github.com/python-poetry/poetry
     rev: "2.1.3"
     hooks:
-    -   id: poetry-check
--   repo: https://github.com/rhysd/actionlint
+      - id: poetry-check
+  - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:
-    -   id: actionlint
--   repo: https://github.com/hadolint/hadolint
+      - id: actionlint
+  - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:
-    -   id: hadolint-docker
--   repo: https://github.com/tox-dev/pyproject-fmt
+      - id: hadolint-docker
+  - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.5.1"
     hooks:
-    -   id: pyproject-fmt
+      - id: pyproject-fmt
     # validates CITATION.cff file formatting expectations
--   repo: https://github.com/citation-file-format/cffconvert
+  - repo: https://github.com/citation-file-format/cffconvert
     rev: b6045d78aac9e02b039703b030588d54d53262ac
     hooks:
-    -   id: validate-cff
--   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+      - id: validate-cff
+  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: v0.7.0
     hooks:
-    -   id: pre-commit-update
+      - id: pre-commit-update
         args: ["--keep", "cffconvert"]

--- a/pycytominer/aggregate.py
+++ b/pycytominer/aggregate.py
@@ -26,7 +26,7 @@ def aggregate(
     subset_data_df: Optional[pd.DataFrame] = None,
     compression_options: Optional[Union[str, dict[str, Any]]] = None,
     float_format: Optional[str] = None,
-) -> Optional[pd.DataFrame]:
+) -> Optional[Union[pd.DataFrame, str]]:
     """Combine population dataframe variables by strata groups using given operation.
 
     Parameters

--- a/pycytominer/annotate.py
+++ b/pycytominer/annotate.py
@@ -136,7 +136,7 @@ def annotate(
     annotated = annotated.loc[:, meta_cols + other_cols]
 
     if output_file is not None:
-        output(
+        return output(
             df=annotated,
             output_filename=output_file,
             output_type=output_type,

--- a/pycytominer/consensus.py
+++ b/pycytominer/consensus.py
@@ -118,7 +118,7 @@ def consensus(
         )
 
     if output_file is not None:
-        output(
+        return output(
             df=consensus_df,
             output_filename=output_file,
             output_type=output_type,

--- a/pycytominer/cyto_utils/DeepProfiler_processing.py
+++ b/pycytominer/cyto_utils/DeepProfiler_processing.py
@@ -473,7 +473,7 @@ class SingleCellDeepProfiler:
 
         # separate code because normalize() will not return if it has an output file specified
         if output_file is not None:
-            output(
+            return output(
                 df=normalized,
                 output_filename=output_file,
                 compression_options=compression_options,

--- a/pycytominer/cyto_utils/output.py
+++ b/pycytominer/cyto_utils/output.py
@@ -20,7 +20,7 @@ def output(
         "mtime": 1,
     },
     **kwargs,
-):
+) -> str:
     """Given an output file and compression options, write file to disk
 
     Parameters

--- a/pycytominer/feature_select.py
+++ b/pycytominer/feature_select.py
@@ -184,7 +184,7 @@ def feature_select(
     selected_df = profiles.drop(excluded_features, axis="columns")
 
     if output_file is not None:
-        output(
+        return output(
             df=selected_df,
             output_filename=output_file,
             output_type=output_type,

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -187,7 +187,7 @@ def normalize(
         raise ValueError(f"{error_detail}. This is likely a bug in {context}.")
 
     if output_file is not None:
-        output(
+        return output(
             df=normalized,
             output_filename=output_file,
             output_type=output_type,

--- a/tests/test_cyto_utils/test_DeepProfiler_processing.py
+++ b/tests/test_cyto_utils/test_DeepProfiler_processing.py
@@ -64,7 +64,7 @@ def test_single_cell(single_cell_deep_profiler):
     meta_cols = [x for x in single_cells.columns if x.startswith("Location_")]
     assert meta_cols.index("Location_Center_X") == 0
     assert meta_cols.index("Location_Center_Y") == 1
-    assert single_cells.shape == (10132, 6417)
+    assert single_cells.shape == (10132, 6418)
     assert not single_cells.isnull().values.any()
 
     # Random value check
@@ -107,7 +107,7 @@ def test_single_cell_normalize(single_cell_deep_profiler):
         filepath_or_buffer=normalize(
             profiles=single_cells,
             features=derived_features,
-            output_file=(output_folder / "standalone_normalize.parquet"),
+            output_file=(output_folder / "standalone_normalized.csv"),
         )
     ).drop(
         # note: We drop metadata_concentration because it includes NaN values
@@ -162,7 +162,7 @@ def test_aggregate(deep_profiler_data):
     )
     df_plate = plate_class.aggregate_deep()
 
-    assert df_site.shape == (36, 6417)
+    assert df_site.shape == (36, 6418)
     assert df_well.shape == (4, 6412)
     assert df_plate.shape == (2, 6406)
 
@@ -188,7 +188,8 @@ def test_output(single_cell_deep_profiler):
 
     files = os.listdir(output_folder)
     files_should_be = [
-        "normalized.csv",
+        "sc_dp_normalized.csv",
+        "standalone_normalized.csv",
         "SQ00014812.csv",
         "SQ00014813.csv",
         "SQ00014812_A01.csv",


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

This PR changes core functions or methods within Pycytominer to return the filepath when using the `output_file` argument. Before this point, when using the `output_file` argument you sometimes would receive a `None` from some but not all functions within Pycytominer. This makes the functionality uniform: if we supply `output_file` we can expect the generated filepath back.

As a result of this change I had to edit DeepProfiler tests to navigate how Pandas reads from CSV files (it translates values for use within those files which in turn changes the values received back).

Thanks for any feedback!

Closes #451

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
