### PR TITLE
fixed modz bug: dropping groups where  contains NaNs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.11"
+    rev: "v0.15.12"
     hooks:
     -   id: ruff-check
         exclude: tutorials/nbconverted/

--- a/pycytominer/cyto_utils/modz.py
+++ b/pycytominer/cyto_utils/modz.py
@@ -150,13 +150,16 @@ def modz(
     subset_features = list(set(replicate_columns + features))
     population_df = population_df.loc[:, subset_features]
 
-    # warn users about using modz with NaN values
-    # NaN values will be treated as a valid group
-    if population_df.isnull().any().any():
+    # warn users about having NaN values in replicate columns
+    if population_df[replicate_columns].isnull().any().any():
         warnings.warn(
-            "NaN values detected. NaNs in 'replicate_columns' form their own "
-            "group; NaNs in 'features' are skipped in correlation but treated "
-            "as 0 in the weighted sum."
+            "NaN values detected. NaNs in 'replicate_columns' form their own group"
+        )
+
+    if population_df[features].isnull().any().any():
+        raise ValueError(
+            "NaN values detected in feature columns. NaNs miscalculate the "
+            "pairwise correlations used to weight samples."
         )
 
     modz_df = (

--- a/pycytominer/cyto_utils/modz.py
+++ b/pycytominer/cyto_utils/modz.py
@@ -2,6 +2,7 @@
 Module for performing MODZ (modified z-score) transformations
 """
 
+import warnings
 from typing import Union
 
 import numpy as np
@@ -149,12 +150,21 @@ def modz(
     subset_features = list(set(replicate_columns + features))
     population_df = population_df.loc[:, subset_features]
 
+    # warn users about using modz with NaN values
+    # NaN values will be treated as a valid group
+    if population_df.isnull().any().any():
+        warnings.warn(
+            "NaN values detected. NaNs in 'replicate_columns' form their own "
+            "group; NaNs in 'features' are skipped in correlation but treated "
+            "as 0 in the weighted sum."
+        )
+
     modz_df = (
         population_df
-        .groupby(replicate_columns)
+        .groupby(replicate_columns, dropna=False)[features]
         .apply(
             lambda x: modz_base(
-                x.loc[:, features],
+                x,
                 method=method,
                 min_weight=min_weight,
                 precision=precision,

--- a/tests/test_cyto_utils/test_modz.py
+++ b/tests/test_cyto_utils/test_modz.py
@@ -204,7 +204,7 @@ def test_modz_nan_in_replicate_columns():
     )
 
     # We expect our newly implemented warning since the input structure contains NaNs
-    with pytest.warns(UserWarning, match="Missing values \\(NaN\\) detected in input."):
+    with pytest.warns(UserWarning, match="NaN values detected."):
         consensus_df = modz(
             data_replicate_nan_df,
             replicate_columns="Metadata_nan",

--- a/tests/test_cyto_utils/test_modz.py
+++ b/tests/test_cyto_utils/test_modz.py
@@ -196,14 +196,11 @@ def test_modz_unbalanced_sample_numbers():
 
 
 def test_modz_nan_in_replicate_columns():
-    # Test to ensure that replicate groups containing NaN are not silently dropped.
-    # Group "c" matches the data pattern from original group "a"
-    # The NaN group matches the data pattern from original group "b"
     data_replicate_nan_df = data_replicate_df.assign(
         Metadata_nan=["c", "c", "c", np.nan, np.nan, np.nan]
     )
 
-    # We expect our newly implemented warning since the input structure contains NaNs
+    # min_weight=0: removes influence of anticorrelated sample
     with pytest.warns(UserWarning, match="NaN values detected."):
         consensus_df = modz(
             data_replicate_nan_df,
@@ -212,8 +209,6 @@ def test_modz_nan_in_replicate_columns():
             precision=precision,
         )
 
-    # The expected result should preserve the exact same continuous outputs as groups 'a' and 'b'
-    # but bound under the labels 'c' and NaN respectively for the new metadata group.
     expected_result = pd.DataFrame(
         {
             "Metadata_nan": ["c", np.nan],
@@ -223,3 +218,38 @@ def test_modz_nan_in_replicate_columns():
         },
     )
     pd.testing.assert_frame_equal(expected_result, consensus_df)
+
+    # min_weight=1: modz is equivalent to mean
+    with pytest.warns(UserWarning, match="NaN values detected."):
+        consensus_df = modz(
+            data_replicate_nan_df,
+            replicate_columns="Metadata_nan",
+            min_weight=1,
+            precision=precision,
+        )
+
+    expected_result = (
+        data_replicate_nan_df
+        .groupby("Metadata_nan", dropna=False)
+        .mean(numeric_only=True)
+        .round(precision)
+        .reset_index()
+    )
+    pd.testing.assert_frame_equal(
+        expected_result, consensus_df, check_exact=False, atol=1e-3
+    )
+
+
+def test_modz_nan_in_feature_space():
+    data_replicate_nan_features_df = data_replicate_df.copy()
+    data_replicate_nan_features_df.iloc[
+        0, data_replicate_nan_features_df.columns.get_loc("Cells_x")
+    ] = np.nan
+
+    with pytest.raises(ValueError, match="NaN values detected"):
+        modz(
+            data_replicate_nan_features_df,
+            replicate_columns="Metadata_g",
+            min_weight=0,
+            precision=precision,
+        )

--- a/tests/test_cyto_utils/test_modz.py
+++ b/tests/test_cyto_utils/test_modz.py
@@ -1,4 +1,6 @@
+import numpy as np
 import pandas as pd
+import pytest
 
 from pycytominer.cyto_utils import modz
 from pycytominer.cyto_utils.modz import modz_base
@@ -188,6 +190,36 @@ def test_modz_unbalanced_sample_numbers():
             "Cells_x": [0.9999, 5.0],
             "Cytoplasm_y": [5.9994, 1.0],
             "Nuclei_z": [2.9997, 1],
+        },
+    )
+    pd.testing.assert_frame_equal(expected_result, consensus_df)
+
+
+def test_modz_nan_in_replicate_columns():
+    # Test to ensure that replicate groups containing NaN are not silently dropped.
+    # Group "c" matches the data pattern from original group "a"
+    # The NaN group matches the data pattern from original group "b"
+    data_replicate_nan_df = data_replicate_df.assign(
+        Metadata_nan=["c", "c", "c", np.nan, np.nan, np.nan]
+    )
+
+    # We expect our newly implemented warning since the input structure contains NaNs
+    with pytest.warns(UserWarning, match="Missing values \\(NaN\\) detected in input."):
+        consensus_df = modz(
+            data_replicate_nan_df,
+            replicate_columns="Metadata_nan",
+            min_weight=0,
+            precision=precision,
+        )
+
+    # The expected result should preserve the exact same continuous outputs as groups 'a' and 'b'
+    # but bound under the labels 'c' and NaN respectively for the new metadata group.
+    expected_result = pd.DataFrame(
+        {
+            "Metadata_nan": ["c", np.nan],
+            "Cells_x": [1.0, 4.0],
+            "Cytoplasm_y": [5.0, 2.0],
+            "Nuclei_z": [2.0, -0.5],
         },
     )
     pd.testing.assert_frame_equal(expected_result, consensus_df)


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description
This PR addresses where consensus(operation="modz") was silently dropping groups that contained NaN values in the replicate_columns.

This was done by updating the `groupby` operation in modz.py to use `dropna=False`. This ensures that NaN values in metadata are treated as valid group identifiers rather than being excluded from the consensus output.

Tests were also generated to reflect this change. 

<!--
Thank you for your contribution to Pycytominer!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

Please also link to any relevant issues that your code is associated with.

For example:
Closes #<GitHub issue number goes here>
-->
This closes #162 and #170 
## What is the nature of your change?

- [X] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have deleted all non-relevant text in this pull request template.
