### PR TITLE
Removal of `noqa: S603` in collate subprocess calls 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.11"
+    rev: "v0.15.12"
     hooks:
     -   id: ruff-check
         exclude: tutorials/nbconverted/

--- a/pycytominer/cyto_utils/collate.py
+++ b/pycytominer/cyto_utils/collate.py
@@ -130,6 +130,7 @@ def collate(
 
             remote_aggregated_file = f"{aws_remote}/backend/{batch}/{plate}/{plate}.csv"
 
+            # Keep the AWS command as argv to avoid shell parsing in subprocess.run.
             sync_cmd = [
                 "aws",
                 "s3",

--- a/pycytominer/cyto_utils/collate.py
+++ b/pycytominer/cyto_utils/collate.py
@@ -8,20 +8,17 @@ import sqlite3
 import subprocess
 import sys
 import warnings
-from typing import Optional, Union
+from typing import Optional
 
 
-def run_check_errors(cmd: Union[str, list]):
+def run_check_errors(cmd: list[str]) -> None:
     """Run a system command, and exit if an error occurred, otherwise continue"""
-    if isinstance(cmd, str):
-        cmd = cmd.split()
-    output = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+    output = subprocess.run(args=cmd, capture_output=True, text=True, check=False)
     if output.stderr != "":
-        print_cmd = " ".join(map(str, cmd))
+        print_cmd = " ".join(cmd)
         sys.exit(
             f"The error {output.stderr} was generated when running {print_cmd}. Exiting."
         )
-    return
 
 
 def collate(
@@ -133,7 +130,23 @@ def collate(
 
             remote_aggregated_file = f"{aws_remote}/backend/{batch}/{plate}/{plate}.csv"
 
-            sync_cmd = f"aws s3 sync --exclude * --include */Cells.csv --include */Nuclei.csv --include */Cytoplasm.csv --include */Image.csv {remote_input_dir} {input_dir}"
+            sync_cmd = [
+                "aws",
+                "s3",
+                "sync",
+                "--exclude",
+                "*",
+                "--include",
+                "*/Cells.csv",
+                "--include",
+                "*/Nuclei.csv",
+                "--include",
+                "*/Cytoplasm.csv",
+                "--include",
+                "*/Image.csv",
+                remote_input_dir,
+                str(input_dir),
+            ]
             if printtoscreen:
                 print(f"Downloading CSVs from {remote_input_dir} to {input_dir}")
             run_check_errors(sync_cmd)
@@ -178,7 +191,7 @@ def collate(
         if aws_remote:
             if printtoscreen:
                 print(f"Uploading {cache_backend_file} to {remote_backend_file}")
-            cp_cmd = ["aws", "s3", "cp", cache_backend_file, remote_backend_file]
+            cp_cmd = ["aws", "s3", "cp", str(cache_backend_file), remote_backend_file]
             run_check_errors(cp_cmd)
 
             if printtoscreen:
@@ -201,7 +214,7 @@ def collate(
 
         remote_aggregated_file = f"{aws_remote}/backend/{batch}/{plate}/{plate}.csv"
 
-        cp_cmd = ["aws", "s3", "cp", remote_backend_file, backend_file]
+        cp_cmd = ["aws", "s3", "cp", remote_backend_file, str(backend_file)]
         if printtoscreen:
             print(
                 f"Downloading SQLite files from {remote_backend_file} to {backend_file}"
@@ -227,7 +240,7 @@ def collate(
     if aws_remote:
         if printtoscreen:
             print(f"Uploading {aggregated_file} to {remote_aggregated_file}")
-        csv_cp_cmd = ["aws", "s3", "cp", aggregated_file, remote_aggregated_file]
+        csv_cp_cmd = ["aws", "s3", "cp", str(aggregated_file), remote_aggregated_file]
         run_check_errors(csv_cp_cmd)
 
         if printtoscreen:

--- a/pycytominer/cyto_utils/modz.py
+++ b/pycytominer/cyto_utils/modz.py
@@ -2,6 +2,7 @@
 Module for performing MODZ (modified z-score) transformations
 """
 
+import warnings
 from typing import Union
 
 import numpy as np
@@ -149,12 +150,21 @@ def modz(
     subset_features = list(set(replicate_columns + features))
     population_df = population_df.loc[:, subset_features]
 
+    # warn users about using modz with NaN values
+    # NaN values will be treated as a valid group
+    if population_df.isnull().any().any():
+        warnings.warn(
+            "NaN values detected. NaNs in 'replicate_columns' form their own "
+            "group; NaNs in 'features' are skipped in correlation but treated "
+            "as 0 in the weighted sum."
+        )
+
     modz_df = (
         population_df
-        .groupby(replicate_columns)
+        .groupby(replicate_columns, dropna=False)[features]
         .apply(
             lambda x: modz_base(
-                x.loc[:, features],
+                x,
                 method=method,
                 min_weight=min_weight,
                 precision=precision,

--- a/tests/test_cyto_utils/test_collate.py
+++ b/tests/test_cyto_utils/test_collate.py
@@ -24,6 +24,7 @@ MAIN_CSV_LOCATION = TEST_DATA_LOCATION / "backend" / BATCH / PLATE / f"{PLATE}_m
 
 
 def test_run_check_errors_uses_command_list(monkeypatch):
+    """Ensure run_check_errors forwards argv-style command lists to subprocess.run."""
     command = ["aws", "s3", "cp", "source.sqlite", "target.sqlite"]
     captured_kwargs = {}
 

--- a/tests/test_cyto_utils/test_collate.py
+++ b/tests/test_cyto_utils/test_collate.py
@@ -1,10 +1,11 @@
 import os
 import pathlib
+import subprocess
 
 import pandas as pd
 import pytest
 
-from pycytominer.cyto_utils.collate import collate
+from pycytominer.cyto_utils.collate import collate, run_check_errors
 
 # Set constants
 BATCH = "2021_04_20_Target2"
@@ -20,6 +21,24 @@ TEST_BACKEND_LOCATION = (
 )
 TEST_CSV_LOCATION = TEST_DATA_LOCATION / "backend" / BATCH / PLATE / f"{PLATE}.csv"
 MAIN_CSV_LOCATION = TEST_DATA_LOCATION / "backend" / BATCH / PLATE / f"{PLATE}_main.csv"
+
+
+def test_run_check_errors_uses_command_list(monkeypatch):
+    command = ["aws", "s3", "cp", "source.sqlite", "target.sqlite"]
+    captured_kwargs = {}
+
+    def mock_run(**kwargs):
+        captured_kwargs.update(kwargs)
+        return subprocess.CompletedProcess(args=kwargs["args"], returncode=0, stderr="")
+
+    monkeypatch.setattr(run_check_errors.__globals__["subprocess"], "run", mock_run)
+
+    run_check_errors(command)
+
+    assert captured_kwargs["args"] == command
+    assert captured_kwargs["capture_output"] is True
+    assert captured_kwargs["text"] is True
+    assert captured_kwargs["check"] is False
 
 
 def cleanup():

--- a/tests/test_cyto_utils/test_modz.py
+++ b/tests/test_cyto_utils/test_modz.py
@@ -1,4 +1,6 @@
+import numpy as np
 import pandas as pd
+import pytest
 
 from pycytominer.cyto_utils import modz
 from pycytominer.cyto_utils.modz import modz_base
@@ -188,6 +190,36 @@ def test_modz_unbalanced_sample_numbers():
             "Cells_x": [0.9999, 5.0],
             "Cytoplasm_y": [5.9994, 1.0],
             "Nuclei_z": [2.9997, 1],
+        },
+    )
+    pd.testing.assert_frame_equal(expected_result, consensus_df)
+
+
+def test_modz_nan_in_replicate_columns():
+    # Test to ensure that replicate groups containing NaN are not silently dropped.
+    # Group "c" matches the data pattern from original group "a"
+    # The NaN group matches the data pattern from original group "b"
+    data_replicate_nan_df = data_replicate_df.assign(
+        Metadata_nan=["c", "c", "c", np.nan, np.nan, np.nan]
+    )
+
+    # We expect our newly implemented warning since the input structure contains NaNs
+    with pytest.warns(UserWarning, match="Missing values \\(NaN\\) detected in input."):
+        consensus_df = modz(
+            data_replicate_nan_df,
+            replicate_columns="Metadata_nan",
+            min_weight=0,
+            precision=precision,
+        )
+
+    # The expected result should preserve the exact same continuous outputs as groups 'a' and 'b'
+    # but bound under the labels 'c' and NaN respectively for the new metadata group.
+    expected_result = pd.DataFrame(
+        {
+            "Metadata_nan": ["c", np.nan],
+            "Cells_x": [1.0, 4.0],
+            "Cytoplasm_y": [5.0, 2.0],
+            "Nuclei_z": [2.0, -0.5],
         },
     )
     pd.testing.assert_frame_equal(expected_result, consensus_df)


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description
In this PR, we remove the `noqa: S603` suppression from `collate.py` by making the subprocess helper use explicit argument lists.

The `run_check_errors` function now accepts `list[str]` commands only, instead of accepting either strings or lists. The AWS sync command was also changed from a single command string into a list of arguments, and path values are converted to strings before being passed to `subprocess.run`.

This keeps the existing subprocess behavior while satisfying Ruff’s `S603` check without ignoring the rule.
<!--
Thank you for your contribution to Pycytominer!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

Please also link to any relevant issues that your code is associated with.
For example:
Closes #<GitHub issue number goes here>
-->
This closes #393 

## What is the nature of your change?

- [X] Bug fix (fixes an issue).
- [X] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have deleted all non-relevant text in this pull request template.
