### PR TITLE
Add contribution interest checkbox to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,3 +40,14 @@ body:
           - Screenshots
           - Operating system
           - Pycytominer version
+  - type: checkboxes
+    id: contribution-interest
+    attributes:
+      label: Contribution interest
+      description: >
+        If you would like to help fix this issue, we would be happy to support
+        you. This is completely optional, but it helps us know when someone is
+        interested in contributing.
+      options:
+        - label: >
+            I would be interested in submitting a pull request to help resolve this issue.

--- a/.github/ISSUE_TEMPLATE/documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request.yml
@@ -29,3 +29,14 @@ body:
         Please provide your suggestion for what changes should be made in the documentation. If your suggestion involves modifying existing documentation, please explain why the suggested change is an improvement.
     validations:
       required: true
+  - type: checkboxes
+    id: contribution-interest
+    attributes:
+      label: Contribution interest
+      description: >
+        If you would like to help improve this documentation, we would be happy
+        to support you. This is completely optional, but it helps us know when
+        someone is interested in contributing.
+      options:
+        - label: >
+            I would be interested in submitting a pull request to help update this documentation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -42,3 +42,14 @@ body:
       label: Additional information
       description: >
         Provide additional information or context.
+  - type: checkboxes
+    id: contribution-interest
+    attributes:
+      label: Contribution interest
+      description: >
+        If you would like to help build this feature, we would be happy to
+        support you. This is completely optional, but it helps us know when
+        someone is interested in contributing.
+      options:
+        - label: >
+            I would be interested in submitting a pull request to help implement this feature.

--- a/.github/ISSUE_TEMPLATE/general_questions.yml
+++ b/.github/ISSUE_TEMPLATE/general_questions.yml
@@ -19,3 +19,14 @@ body:
         Please provide the question or a description of the issue.
     validations:
       required: true
+  - type: checkboxes
+    id: contribution-interest
+    attributes:
+      label: Contribution interest
+      description: >
+        If you would like to help follow up on this issue, we would be happy to
+        support you. This is completely optional, but it helps us know when
+        someone is interested in contributing.
+      options:
+        - label: >
+            I would be interested in submitting a pull request to help resolve this issue.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.11"
+    rev: "v0.15.12"
     hooks:
     -   id: ruff-check
         exclude: tutorials/nbconverted/


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description
This PR adds an optional **Contribution interest** checkbox to the issue templates in `.github/ISSUE_TEMPLATE`.

The checkbox gives issue submitters a  welcome to  indicate whether they are interested in submitting a PR to help resolve the issue.

Updated templates:
- `bug_report.yml`
- `feature_request.yml`
- `documentation_request.yml`
- `general_questions.yml`
<!--
Thank you for your contribution to Pycytominer!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

Please also link to any relevant issues that your code is associated with.
For example:
Closes #<GitHub issue number goes here>
-->
Closes #322 

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have deleted all non-relevant text in this pull request template.
