### PR TITLE
Remove S108 ignores from collate temp directory defaults

### DIFF
--- a/pycytominer/cyto_utils/collate.py
+++ b/pycytominer/cyto_utils/collate.py
@@ -7,6 +7,7 @@ import pathlib
 import sqlite3
 import subprocess
 import sys
+import tempfile
 import warnings
 from typing import Optional, Union
 
@@ -34,7 +35,7 @@ def collate(
     csv_dir: str = "analysis",
     aws_remote: Optional[str] = None,
     aggregate_only: bool = False,
-    tmp_dir: str = "/tmp",  # noqa: S108
+    tmp_dir: Optional[str] = None,
     overwrite: bool = False,
     add_image_features: bool = True,
     image_feature_categories: Optional[list[str]] = [
@@ -67,8 +68,9 @@ def collate(
         A remote AWS prefix, if set CSV files will be synced down from at the beginning and to which SQLite files will be synced up at the end of the run
     aggregate_only : bool, default False
         Whether to perform only the aggregation of existent SQLite files and bypass previous collation steps
-    tmp_dir: str, default '/tmp'
-        The temporary directory to be used by cytominer-databases for output
+    tmp_dir: str, optional
+        The temporary directory to be used by cytominer-databases for output. If
+        not provided, the system temporary directory is used.
     overwrite: bool, optional, default False
         Whether or not to overwrite an sqlite that exists in the temporary directory if it already exists
     add_image_features: bool, optional, default True
@@ -105,6 +107,7 @@ def collate(
     )
 
     # Set up directories (these need to be abspaths to keep from confusing makedirs later)
+    tmp_dir = tempfile.gettempdir() if tmp_dir is None else tmp_dir
     input_dir = pathlib.Path(f"{base_directory}/analysis/{batch}/{plate}/{csv_dir}")
     backend_dir = pathlib.Path(f"{base_directory}/backend/{batch}/{plate}")
     cache_backend_dir = pathlib.Path(f"{tmp_dir}/backend/{batch}/{plate}")

--- a/pycytominer/cyto_utils/collate_cmd.py
+++ b/pycytominer/cyto_utils/collate_cmd.py
@@ -3,6 +3,7 @@ Build a CLI for collate function
 """
 
 import argparse
+import tempfile
 
 from pycytominer.cyto_utils.collate import collate
 
@@ -51,7 +52,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tmp-dir",
         dest="tmp_dir",
-        default="/tmp",  # noqa: S108
+        default=tempfile.gettempdir(),
         help="The temporary directory to be used by cytominer-databases for output",
     )
     parser.add_argument(


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description
This PR removes the remaining `# noqa: S108` ignores from `pycytominer.cyto_utils.collate`.

It replaces hard-coded `"/tmp"` defaults with `tempfile.gettempdir()`, preserving the existing default behavior while satisfying Ruff/Bandit’s `S108` check. The `collate()` function now resolves the default temp directory internally when `tmp_dir` is not provided, and the CLI uses the same system temp directory default.

<!--
Thank you for your contribution to Pycytominer!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

Please also link to any relevant issues that your code is associated with.
For example:
Closes #<GitHub issue number goes here>
-->
This closes #394

## What is the nature of your change?

- [X] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have deleted all non-relevant text in this pull request template.
