### PR TITLE
Make `SingleCells.count_cells()` use configurable count columns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.11"
+    rev: "v0.15.12"
     hooks:
     -   id: ruff-check
         exclude: tutorials/nbconverted/

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -329,9 +329,13 @@ class SingleCells:
         compartment : str, default "cells"
             Compartment to subset.
         merge_cols : list[str], default ["TableNumber", "ImageNumber"]
-            Columns used to merge image and compartment tables for counting.
+            Columns used to merge image and compartment tables when falling back
+            to object-level counting. Must include at least one column when
+            image_count_col is unavailable.
         object_col : str, default "ObjectNumber"
-            Column used as the object identifier to count.
+            Column used as the object identifier when falling back to
+            object-level counting. Must be non-empty when image_count_col is
+            unavailable.
         image_count_col : str, default "Count_Cells"
             Image-level count column to sum by strata before falling back to
             object-level counting.
@@ -401,14 +405,16 @@ class SingleCells:
                 )
                 return count_df
 
-            # if merge_cols is empty, raise an error since we need merge columns to
-            # merge image and compartment data for counting.
+            # Fall back to object-level counting when an image-level count column
+            # is unavailable in both the loaded image data and the SQL image table.
+            # This path requires merge columns to attach image metadata to object
+            # rows before grouping by strata.
             if len(merge_cols) < 1:
                 raise ValueError("merge_cols must include at least one merge column.")
 
-            # if object_col is empty, raise an error since we need an object column to
-            # count the number of cells per strata.
-            if len(object_col) == 0:
+            # This path also requires an object identifier column to count objects
+            # per strata.
+            if not object_col:
                 raise ValueError("object_col must be a non-empty column name.")
 
             # specify query to get the columns needed for counting cells per group

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -315,7 +315,11 @@ class SingleCells:
         self.image_data_loaded = True
 
     def count_cells(
-        self, compartment: str = "cells", count_subset: bool = False
+        self,
+        compartment: str = "cells",
+        merge_cols: list[str] = ["TableNumber", "ImageNumber"],
+        object_col: str = "ObjectNumber",
+        count_subset: bool = False,
     ) -> pd.DataFrame:
         """Determine how many cells are measured per well.
 
@@ -323,6 +327,10 @@ class SingleCells:
         ----------
         compartment : str, default "cells"
             Compartment to subset.
+        merge_cols : list[str], default ["TableNumber", "ImageNumber"]
+            Columns used to merge image and compartment tables for counting.
+        object_col : str, default "ObjectNumber"
+            Column used as the object identifier to count.
         count_subset : bool, default False
             Whether or not count the number of cells as specified by the strata groups.
 
@@ -353,17 +361,30 @@ class SingleCells:
                 .rename({"Metadata_ObjectNumber": "cell_count"}, axis="columns")
             )
         else:
-            query_cols = "TableNumber, ImageNumber, ObjectNumber"
+            if len(merge_cols) < 1:
+                raise ValueError(
+                    "merge_cols must include at least one merge column."
+                )
+
+            if len(object_col) == 0:
+                raise ValueError(
+                    "object_col must be a non-empty column name."
+                )
+
+            # specify query to get the columns needed for counting cells per group
+            query_cols = ", ".join([*merge_cols, object_col])
             query = f"select {query_cols} from {compartment}"
+
+            # count the number of cells per group by merging image and compartment data
             count_df = self.image_df.merge(
-                pd.read_sql(sql=query, con=self.conn), how="inner", on=self.merge_cols
+                pd.read_sql(sql=query, con=self.conn), how="inner", on=merge_cols
             )
             count_df = (
                 count_df
-                .groupby(self.strata)["ObjectNumber"]
+                .groupby(self.strata)[object_col]
                 .count()
                 .reset_index()
-                .rename({"ObjectNumber": "cell_count"}, axis="columns")
+                .rename({object_col: "cell_count"}, axis="columns")
             )
 
         return count_df

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -379,10 +379,10 @@ class SingleCells:
                     .rename({image_count_col: "cell_count"}, axis="columns")
                 )
                 return count_df
-            image_table_col_names = self.get_sql_table_col_names(self.image_table_name)
-
+            
             # if the image-level count column is present in the image table, use it to
             # compute cell counts per strata.
+            image_table_col_names = self.get_sql_table_col_names(self.image_table_name)
             if image_count_col in image_table_col_names:
                 image_count_query_cols = ", ".join([*self.merge_cols, image_count_col])
                 image_count_query = (

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -362,10 +362,10 @@ class SingleCells:
 
             count_df = (
                 self.subset_data_df
-                .groupby(self.strata)["Metadata_ObjectNumber"]
+                .groupby(self.strata)[self.object_feature]
                 .count()
                 .reset_index()
-                .rename({"Metadata_ObjectNumber": "cell_count"}, axis="columns")
+                .rename({self.object_feature: "cell_count"}, axis="columns")
             )
         else:
             # prefer image-level count feature when available, then fallback to object
@@ -499,7 +499,7 @@ class SingleCells:
 
         check_compartments(compartment)
 
-        query_cols = "TableNumber, ImageNumber, ObjectNumber"
+        query_cols = ", ".join([*self.merge_cols, "ObjectNumber"])
         query = f"select {query_cols} from {compartment}"
 
         # Load query and merge with image_df

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -379,7 +379,7 @@ class SingleCells:
                     .rename({image_count_col: "cell_count"}, axis="columns")
                 )
                 return count_df
-            
+
             # if the image-level count column is present in the image table, use it to
             # compute cell counts per strata.
             image_table_col_names = self.get_sql_table_col_names(self.image_table_name)

--- a/pycytominer/cyto_utils/cells.py
+++ b/pycytominer/cyto_utils/cells.py
@@ -319,6 +319,7 @@ class SingleCells:
         compartment: str = "cells",
         merge_cols: list[str] = ["TableNumber", "ImageNumber"],
         object_col: str = "ObjectNumber",
+        image_count_col: str = "Count_Cells",
         count_subset: bool = False,
     ) -> pd.DataFrame:
         """Determine how many cells are measured per well.
@@ -331,6 +332,9 @@ class SingleCells:
             Columns used to merge image and compartment tables for counting.
         object_col : str, default "ObjectNumber"
             Column used as the object identifier to count.
+        image_count_col : str, default "Count_Cells"
+            Image-level count column to sum by strata before falling back to
+            object-level counting.
         count_subset : bool, default False
             Whether or not count the number of cells as specified by the strata groups.
 
@@ -342,6 +346,9 @@ class SingleCells:
 
         check_compartments([compartment])
 
+        # count the number of cells per group by merging image and compartment data
+        # if count_subset is True, otherwise use image-level count or object counting
+        # without merging
         if count_subset:
             if not self.is_aggregated:
                 raise RuntimeError("Make sure to aggregate_profiles() first!")
@@ -361,15 +368,48 @@ class SingleCells:
                 .rename({"Metadata_ObjectNumber": "cell_count"}, axis="columns")
             )
         else:
-            if len(merge_cols) < 1:
-                raise ValueError(
-                    "merge_cols must include at least one merge column."
+            # prefer image-level count feature when available, then fallback to object
+            # counting.
+            if image_count_col in self.image_df.columns:
+                count_df = (
+                    self.image_df
+                    .groupby(self.strata)[image_count_col]
+                    .sum()
+                    .reset_index()
+                    .rename({image_count_col: "cell_count"}, axis="columns")
                 )
+                return count_df
+            image_table_col_names = self.get_sql_table_col_names(self.image_table_name)
 
-            if len(object_col) == 0:
-                raise ValueError(
-                    "object_col must be a non-empty column name."
+            # if the image-level count column is present in the image table, use it to
+            # compute cell counts per strata.
+            if image_count_col in image_table_col_names:
+                image_count_query_cols = ", ".join([*self.merge_cols, image_count_col])
+                image_count_query = (
+                    f"select {image_count_query_cols} from {self.image_table_name}"
                 )
+                image_count_df = pd.read_sql(sql=image_count_query, con=self.conn)
+                count_df = self.image_df.merge(
+                    image_count_df, how="inner", on=self.merge_cols
+                )
+                count_df = (
+                    count_df
+                    .groupby(self.strata)[image_count_col]
+                    .sum()
+                    .reset_index()
+                    .rename({image_count_col: "cell_count"}, axis="columns")
+                )
+                return count_df
+
+            # if merge_cols is empty, raise an error since we need merge columns to
+            # merge image and compartment data for counting.
+            if len(merge_cols) < 1:
+                raise ValueError("merge_cols must include at least one merge column.")
+
+            # if object_col is empty, raise an error since we need an object column to
+            # count the number of cells per strata.
+            if len(object_col) == 0:
+                raise ValueError("object_col must be a non-empty column name.")
 
             # specify query to get the columns needed for counting cells per group
             query_cols = ", ".join([*merge_cols, object_col])

--- a/tests/test_cyto_utils/test_cells.py
+++ b/tests/test_cyto_utils/test_cells.py
@@ -331,6 +331,36 @@ def test_SingleCells_count_without_tablenumber_uses_explicit_count_cols():
     pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
 
 
+def test_SingleCells_get_subsample_without_tablenumber_uses_merge_cols():
+    tmp_sqlite_file = f"sqlite:///{TMPDIR}/test_get_subsample_no_tablenumber.sqlite"
+    test_engine = create_engine(tmp_sqlite_file)
+
+    image_df = IMAGE_DF.drop(columns=["TableNumber"])
+    cells_df = CELLS_DF.drop(columns=["TableNumber"])
+
+    image_df.to_sql(name="image", con=test_engine, index=False, if_exists="replace")
+    cells_df.to_sql(name="cells", con=test_engine, index=False, if_exists="replace")
+
+    ap = SingleCells(
+        sql_file=tmp_sqlite_file,
+        compartments=["cells"],
+        compartment_linking_cols={"cells": {}},
+        merge_cols=["ImageNumber"],
+        image_cols=["ImageNumber", "Metadata_Site"],
+        object_feature="ObjectNumber",
+        subsample_n=2,
+    )
+    assert isinstance(ap.aggregate_profiles(compute_subsample=True), pd.DataFrame)
+
+    count_df = ap.count_cells(count_subset=True)
+    expected_count = pd.DataFrame({
+        "Metadata_Plate": ["plate", "plate"],
+        "Metadata_Well": ["A01", "A02"],
+        "cell_count": [2, 2],
+    })
+    pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
+
+
 def test_load_compartment():
     loaded_compartment_df = AP.load_compartment(compartment="cells")
     pd.testing.assert_frame_equal(

--- a/tests/test_cyto_utils/test_cells.py
+++ b/tests/test_cyto_utils/test_cells.py
@@ -282,6 +282,34 @@ def test_SingleCells_count_prefers_image_count_cells():
     pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
 
 
+def test_SingleCells_count_uses_loaded_image_count_cells(tmp_path):
+    tmp_sqlite_file = f"sqlite:///{tmp_path / 'test_count_cells_loaded_image.sqlite'}"
+    test_engine = create_engine(tmp_sqlite_file)
+
+    image_df = pd.DataFrame({
+        "TableNumber": ["x_hash", "y_hash", "z_hash"],
+        "ImageNumber": ["x", "y", "z"],
+        "Metadata_Plate": ["plate", "plate", "plate"],
+        "Metadata_Well": ["A01", "A01", "A02"],
+        "Metadata_Site": [1, 2, 1],
+        "Count_Cells": [4, 6, 11],
+    })
+    image_df.to_sql(name="image", con=test_engine, index=False, if_exists="replace")
+
+    ap = SingleCells(
+        sql_file=tmp_sqlite_file,
+        image_cols=["TableNumber", "ImageNumber", "Metadata_Site", "Count_Cells"],
+    )
+    count_df = ap.count_cells()
+
+    expected_count = pd.DataFrame({
+        "Metadata_Plate": ["plate", "plate"],
+        "Metadata_Well": ["A01", "A02"],
+        "cell_count": [10, 11],
+    })
+    pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
+
+
 def test_SingleCells_count_uses_configured_image_count_col():
     tmp_sqlite_file = f"sqlite:///{TMPDIR}/test_count_cells_custom_image_col.sqlite"
     test_engine = create_engine(tmp_sqlite_file)
@@ -329,6 +357,42 @@ def test_SingleCells_count_without_tablenumber_uses_explicit_count_cols():
         "cell_count": [50, 50],
     })
     pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
+
+
+def test_SingleCells_count_requires_merge_cols_for_object_counting():
+    with pytest.raises(
+        ValueError, match="merge_cols must include at least one merge column"
+    ):
+        AP.count_cells(merge_cols=[])
+
+
+def test_SingleCells_count_requires_object_col_for_object_counting():
+    with pytest.raises(ValueError, match="object_col must be a non-empty column name"):
+        AP.count_cells(object_col="")
+
+
+def test_SingleCells_count_subset_requires_aggregation():
+    ap = SingleCells(sql_file=TMP_SQLITE_FILE)
+
+    with pytest.raises(RuntimeError, match="Make sure to aggregate_profiles"):
+        ap.count_cells(count_subset=True)
+
+
+def test_SingleCells_count_subset_requires_subsample():
+    ap = SingleCells(sql_file=TMP_SQLITE_FILE)
+    ap.is_aggregated = True
+
+    with pytest.raises(RuntimeError, match="Make sure to get_subsample"):
+        ap.count_cells(count_subset=True)
+
+
+def test_SingleCells_count_subset_requires_subset_data():
+    ap = SingleCells(sql_file=TMP_SQLITE_FILE)
+    ap.is_aggregated = True
+    ap.is_subset_computed = True
+
+    with pytest.raises(RuntimeError, match=r"count_cells\(\) did not set subset_data_df"):
+        ap.count_cells(count_subset=True)
 
 
 def test_SingleCells_get_subsample_without_tablenumber_uses_merge_cols():

--- a/tests/test_cyto_utils/test_cells.py
+++ b/tests/test_cyto_utils/test_cells.py
@@ -391,7 +391,9 @@ def test_SingleCells_count_subset_requires_subset_data():
     ap.is_aggregated = True
     ap.is_subset_computed = True
 
-    with pytest.raises(RuntimeError, match=r"count_cells\(\) did not set subset_data_df"):
+    with pytest.raises(
+        RuntimeError, match=r"count_cells\(\) did not set subset_data_df"
+    ):
         ap.count_cells(count_subset=True)
 
 

--- a/tests/test_cyto_utils/test_cells.py
+++ b/tests/test_cyto_utils/test_cells.py
@@ -272,6 +272,44 @@ def test_SingleCells_count():
     pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
 
 
+def test_SingleCells_count_prefers_image_count_cells():
+    count_df = AP_IMAGE_COUNT.count_cells()
+    expected_count = pd.DataFrame({
+        "Metadata_Plate": ["plate"],
+        "Metadata_Well": ["A01"],
+        "cell_count": [100],
+    })
+    pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
+
+
+def test_SingleCells_count_uses_configured_image_count_col():
+    tmp_sqlite_file = f"sqlite:///{TMPDIR}/test_count_cells_custom_image_col.sqlite"
+    test_engine = create_engine(tmp_sqlite_file)
+
+    image_df = pd.DataFrame({
+        "TableNumber": ["x_hash", "y_hash"],
+        "ImageNumber": ["x", "y"],
+        "Metadata_Plate": ["plate", "plate"],
+        "Metadata_Well": ["A01", "A01"],
+        "Metadata_Site": [1, 2],
+        "Cells_Per_Image": [2, 3],
+    })
+    cells_df = build_random_data(compartment="cells")
+
+    image_df.to_sql(name="image", con=test_engine, index=False, if_exists="replace")
+    cells_df.to_sql(name="cells", con=test_engine, index=False, if_exists="replace")
+
+    ap = SingleCells(sql_file=tmp_sqlite_file)
+    count_df = ap.count_cells(image_count_col="Cells_Per_Image")
+
+    expected_count = pd.DataFrame({
+        "Metadata_Plate": ["plate"],
+        "Metadata_Well": ["A01"],
+        "cell_count": [5],
+    })
+    pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
+
+
 def test_SingleCells_count_without_tablenumber_uses_explicit_count_cols():
     tmp_sqlite_file = f"sqlite:///{TMPDIR}/test_count_cells_no_tablenumber.sqlite"
     test_engine = create_engine(tmp_sqlite_file)

--- a/tests/test_cyto_utils/test_cells.py
+++ b/tests/test_cyto_utils/test_cells.py
@@ -272,6 +272,27 @@ def test_SingleCells_count():
     pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
 
 
+def test_SingleCells_count_without_tablenumber_uses_explicit_count_cols():
+    tmp_sqlite_file = f"sqlite:///{TMPDIR}/test_count_cells_no_tablenumber.sqlite"
+    test_engine = create_engine(tmp_sqlite_file)
+
+    image_df = IMAGE_DF.copy()
+    cells_df = CELLS_DF.drop(columns=["TableNumber"])
+
+    image_df.to_sql(name="image", con=test_engine, index=False, if_exists="replace")
+    cells_df.to_sql(name="cells", con=test_engine, index=False, if_exists="replace")
+
+    ap = SingleCells(sql_file=tmp_sqlite_file)
+    count_df = ap.count_cells(merge_cols=["ImageNumber"], object_col="ObjectNumber")
+
+    expected_count = pd.DataFrame({
+        "Metadata_Plate": ["plate", "plate"],
+        "Metadata_Well": ["A01", "A02"],
+        "cell_count": [50, 50],
+    })
+    pd.testing.assert_frame_equal(count_df, expected_count, check_names=False)
+
+
 def test_load_compartment():
     loaded_compartment_df = AP.load_compartment(compartment="cells")
     pd.testing.assert_frame_equal(


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

In this PR, we replace hard-coded column references in `SingleCells.count_cells()` with configurable parameters. This makes cell counting more flexible for SQLite files that do not use the default CellProfiler column names.

**Changes**
- Adds configurable parameters for cell-counting columns in `SingleCells.count_cells()`.
- Allows callers to specify custom `merge_cols`, `object_col`, and `image_count_col`.
- Updates cell-count logic to use image-level count columns when available.
- Falls back to object-level counting when an image-level count column is not available.
- Adds test coverage for custom image count columns and custom merge columns.

This was done due to some  CellProfiler exports or downstream SQLite schemas may not include the default hard-coded columns such as `TableNumber`, `ObjectNumber`, or `Count_Cells`. This update lets users count cells correctly across alternate schemas without modifying their input data.

# Description

<!--
Thank you for your contribution to Pycytominer!
Please _succinctly_ summarize your proposed change.
What motivated you to make this change?

Please also link to any relevant issues that your code is associated with.
For example:
Closes #<GitHub issue number goes here>
-->
This closes #261  and #80 
## What is the nature of your change?

- [X] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.
