### PR TITLE
Add drop qc rows parameter in normalize with test

### DIFF
--- a/pycytominer/cli.py
+++ b/pycytominer/cli.py
@@ -197,6 +197,7 @@ class PycytominerCLI:
         meta_features: str | Sequence[str] = "infer",
         samples: str = "all",
         method: str = "standardize",
+        drop_cosmicqc_rows: bool = False,
         output_type: Literal["csv", "parquet", "anndata_h5ad", "anndata_zarr"]
         | None = "csv",
         compression_options: str | dict[str, Any] | None = None,
@@ -216,6 +217,7 @@ class PycytominerCLI:
             meta_features: Metadata list or "infer" for metadata inference.
             samples: Query string to choose normalization samples.
             method: Normalization method.
+            drop_cosmicqc_rows: Whether to drop rows flagged by Metadata_cqc_ columns.
             output_type: Output type to write.
             compression_options: Compression options for writing output.
             float_format: Decimal precision for output formatting.
@@ -243,6 +245,7 @@ class PycytominerCLI:
             meta_features=meta_features_value,
             samples=samples,
             method=method,
+            drop_cosmicqc_rows=drop_cosmicqc_rows,
             output_file=output_file,
             output_type=output_type,
             compression_options=compression_options,

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -22,7 +22,7 @@ def normalize(
     meta_features: Union[str, list[str]] = "infer",
     samples: str = "all",
     method: str = "standardize",
-    drop_qc_rows: bool = False,
+    drop_cosmicqc_rows: bool = False,
     output_file: Optional[str] = None,
     output_type: Optional[
         Literal["csv", "parquet", "anndata_h5ad", "anndata_zarr"]
@@ -71,9 +71,10 @@ def normalize(
     method : str
         How to normalize the dataframe. Defaults to "standardize". Check avail_methods
         for available normalization methods.
-    drop_qc_rows : bool
+    drop_cosmicqc_rows : bool
         Whether to drop rows that are flagged as QC failures. The function looks for columns
         from coSMicQC with "Metadata_cqc_" prefix and drop rows with True. Defaults to False.
+        Suggested use after a prior call to `pycytominer.annotate(external_metadata=qc.parquet)`.
     output_file : str, optional
         If provided, will write normalized profiles to file. If not specified, will
         return the normalized profiles as output. We recommend that this output file be
@@ -161,8 +162,8 @@ def normalize(
     # Load Data
     profiles = load_profiles(profiles)
 
-    # If drop_qc_rows is True, drop rows that are flagged (True) as QC failures from coSMicQC
-    if drop_qc_rows:
+    # If drop_cosmicqc_rows is True, drop rows that are flagged (True) as QC failures from coSMicQC
+    if drop_cosmicqc_rows:
         qc_columns = [
             col for col in profiles.columns if col.startswith("Metadata_cqc_")
         ]

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -169,6 +169,10 @@ def normalize(
         if qc_columns:
             passed_qc = ~profiles[qc_columns].any(axis="columns")
             profiles = profiles[passed_qc]
+            if profiles.empty:
+                raise ValueError(
+                    "All rows were dropped after QC filtering; cannot normalize an empty dataset."
+                )
         else:
             raise ValueError(
                 "No QC columns found with prefix 'Metadata_cqc_'. Cannot drop QC rows."

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -165,8 +165,8 @@ def normalize(
     if drop_qc_rows:
         qc_columns = [col for col in profiles.columns if col.startswith("Metadata_cqc_")]
         if qc_columns:
-            qc_filter = np.logical_not(profiles[qc_columns].any(axis="columns"))
-            profiles = profiles[qc_filter]
+            passed_qc = ~profiles[qc_columns].any(axis="columns")
+            profiles = profiles[passed_qc]
         else:
             raise ValueError(
                 "No QC columns found with prefix 'Metadata_cqc_'. Cannot drop QC rows."

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -22,6 +22,7 @@ def normalize(
     meta_features: Union[str, list[str]] = "infer",
     samples: str = "all",
     method: str = "standardize",
+    drop_qc_rows: bool = False,
     output_file: Optional[str] = None,
     output_type: Optional[
         Literal["csv", "parquet", "anndata_h5ad", "anndata_zarr"]
@@ -70,6 +71,9 @@ def normalize(
     method : str
         How to normalize the dataframe. Defaults to "standardize". Check avail_methods
         for available normalization methods.
+    drop_qc_rows : bool
+        Whether to drop rows that are flagged as QC failures. The function looks for columns
+        from coSMicQC with "Metadata_cqc_" prefix and drop rows with True. Defaults to False.
     output_file : str, optional
         If provided, will write normalized profiles to file. If not specified, will
         return the normalized profiles as output. We recommend that this output file be
@@ -156,6 +160,17 @@ def normalize(
 
     # Load Data
     profiles = load_profiles(profiles)
+
+    # If drop_qc_rows is True, drop rows that are flagged (True) as QC failures from coSMicQC
+    if drop_qc_rows:
+        qc_columns = [col for col in profiles.columns if col.startswith("Metadata_cqc_")]
+        if qc_columns:
+            qc_filter = np.logical_not(profiles[qc_columns].any(axis="columns"))
+            profiles = profiles[qc_filter]
+        else:
+            raise ValueError(
+                "No QC columns found with prefix 'Metadata_cqc_'. Cannot drop QC rows."
+            )
 
     # Define which scaler to use
     method = method.lower()

--- a/pycytominer/normalize.py
+++ b/pycytominer/normalize.py
@@ -163,7 +163,9 @@ def normalize(
 
     # If drop_qc_rows is True, drop rows that are flagged (True) as QC failures from coSMicQC
     if drop_qc_rows:
-        qc_columns = [col for col in profiles.columns if col.startswith("Metadata_cqc_")]
+        qc_columns = [
+            col for col in profiles.columns if col.startswith("Metadata_cqc_")
+        ]
         if qc_columns:
             passed_qc = ~profiles[qc_columns].any(axis="columns")
             profiles = profiles[passed_qc]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,7 +126,11 @@ def test_cli_normalize_drop_cosmicqc_rows(tmp_path: pathlib.Path) -> None:
 
     result = pd.read_csv(output_path)
     assert result["Metadata_Well"].tolist() == ["A01", "A03", "A04"]
-    assert result["Metadata_cqc_clustered_nuclei_is_outlier"].tolist() == [False, False, False]
+    assert result["Metadata_cqc_clustered_nuclei_is_outlier"].tolist() == [
+        False,
+        False,
+        False,
+    ]
     assert np.allclose(
         result["Feature_1"],
         [-1.224744871391589, 0.0, 1.224744871391589],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,42 @@ def test_cli_normalize(tmp_path: pathlib.Path) -> None:
     assert np.isclose(result["Feature_2"].mean(), 0.0, atol=1e-7)
 
 
+def test_cli_normalize_drop_cosmicqc_rows(tmp_path: pathlib.Path) -> None:
+    """Ensure CLI normalize forwards drop_cosmicqc_rows."""
+    profiles = pd.DataFrame({
+        "Metadata_Plate": ["P1"] * 4,
+        "Metadata_Well": ["A01", "A02", "A03", "A04"],
+        "Metadata_cqc_clustered_nuclei_is_outlier": [False, True, False, False],
+        "Feature_1": [0.0, 1000.0, 1.0, 2.0],
+        "Feature_2": [10.0, 9999.0, 20.0, 30.0],
+    })
+    profiles_path = tmp_path / "profiles_qc.csv"
+    profiles.to_csv(profiles_path, index=False)
+    output_path = tmp_path / "normalized_qc.csv"
+
+    cli = PycytominerCLI()
+    cli.normalize(
+        profiles=str(profiles_path),
+        output_file=str(output_path),
+        features="Feature_1,Feature_2",
+        meta_features="Metadata_Plate,Metadata_Well,Metadata_cqc_clustered_nuclei_is_outlier",
+        method="standardize",
+        drop_cosmicqc_rows=True,
+    )
+
+    result = pd.read_csv(output_path)
+    assert result["Metadata_Well"].tolist() == ["A01", "A03", "A04"]
+    assert result["Metadata_cqc_clustered_nuclei_is_outlier"].tolist() == [False, False, False]
+    assert np.allclose(
+        result["Feature_1"],
+        [-1.224744871391589, 0.0, 1.224744871391589],
+    )
+    assert np.allclose(
+        result["Feature_2"],
+        [-1.224744871391589, 0.0, 1.224744871391589],
+    )
+
+
 def test_cli_feature_select(tmp_path: pathlib.Path) -> None:
     """Ensure CLI feature_select drops low-variance features."""
     _, profiles_path = _write_profiles(tmp_path)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -430,7 +430,7 @@ def test_normalize_standardize_ctrlsamples():
     pd.testing.assert_frame_equal(normalize_result, expected_result)
 
 
-def test_normalize_drop_qc_rows_before_normalization():
+def test_normalize_drop_cosmicqc_rows_before_normalization():
     profiles = pd.DataFrame({
         "Metadata_plate": ["plate_1"] * 4,
         "Metadata_well": ["A01", "A02", "A03", "A04"],
@@ -445,7 +445,7 @@ def test_normalize_drop_qc_rows_before_normalization():
         meta_features="infer",
         samples="all",
         method="standardize",
-        drop_qc_rows=True,
+        drop_cosmicqc_rows=True,
     )
 
     expected_result = pd.DataFrame(
@@ -461,6 +461,91 @@ def test_normalize_drop_qc_rows_before_normalization():
 
     pd.testing.assert_frame_equal(normalize_result, expected_result)
 
+def test_normalize_drop_cosmicqc_rows_error_when_qc_columns_missing():
+    """
+    Testing the normalize pycytominer function
+    drop_cosmicqc_rows = True when there are
+    no QC columns in the dataframe.
+    """
+    profiles = pd.DataFrame({
+        "Metadata_plate": ["plate_1"] * 4,
+        "Metadata_well": ["A01", "A02", "A03", "A04"],
+        "Cells_x": [0, 1000, 1, 2],
+        "Nuclei_y": [10, 9999, 20, 30],
+    })
+
+    with pytest.raises(ValueError, match="QC columns"):
+        normalize(
+            profiles=profiles,
+            features="infer",
+            meta_features="infer",
+            samples="all",
+            method="standardize",
+            drop_cosmicqc_rows=True,
+        )
+
+def test_normalize_drop_cosmicqc_rows_drops_rows_with_true():
+    """
+    Testing the normalize pycytominer function
+    drop_cosmicqc_rows = True when all rows
+    are True and all rows will be dropped.
+    """
+    profiles = pd.DataFrame({
+        "Metadata_plate": ["plate_1"] * 4,
+        "Metadata_well": ["A01", "A02", "A03", "A04"],
+        "Metadata_cqc_clustered_nuclei_is_outlier": [True] * 4,
+        "Cells_x": [0, 1000, 1, 2],
+        "Nuclei_y": [10, 9999, 20, 30],
+    })
+
+    with pytest.raises(ValueError, match="All rows were dropped"):
+        normalize(
+            profiles=profiles,
+            features="infer",
+            meta_features="infer",
+            samples="all",
+            method="standardize",
+            drop_cosmicqc_rows=True,
+        )
+
+def test_normalize_drop_cosmicqc_rows_multiple_qc_columns():
+    """
+    Testing the normalize pycytominer function
+    drop_cosmicqc_rows = True when there are multiple
+    QC columns and rows with True in any of the QC columns
+    will be dropped.
+    """
+    profiles = pd.DataFrame({
+        "Metadata_plate": ["plate_1"] * 4,
+        "Metadata_well": ["A01", "A02", "A03", "A04"],
+        "Metadata_cqc_clustered_nuclei_is_outlier": [False, True, False, False],
+        "Metadata_cqc_abnormal_small_cell_is_outlier": [False, False, True, False],
+        "Cells_x": [0, 1000, 1, 2],
+        "Nuclei_y": [10, 9999, 20, 30],
+    })
+
+    normalize_result = normalize(
+        profiles=profiles,
+        features="infer",
+        meta_features="infer",
+        samples="all",
+        method="standardize",
+        drop_cosmicqc_rows=True,
+    )
+
+    expected_result = pd.DataFrame(
+        {
+            "Metadata_plate": ["plate_1"] * 2,
+            "Metadata_well": ["A01", "A04"],
+            "Metadata_cqc_clustered_nuclei_is_outlier": [False, False],
+            "Metadata_cqc_abnormal_small_cell_is_outlier": [False, False],
+            "Cells_x": [-1.0, 1.0],
+            "Nuclei_y": [-1.0, 1.0],
+        },
+        index=[0, 3],
+    )
+
+    pd.testing.assert_frame_equal(normalize_result, expected_result)
 
 def test_normalize_robustize_allsamples():
     """

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -430,6 +430,38 @@ def test_normalize_standardize_ctrlsamples():
     pd.testing.assert_frame_equal(normalize_result, expected_result)
 
 
+def test_normalize_drop_qc_rows_before_normalization():
+    profiles = pd.DataFrame({
+        "Metadata_plate": ["plate_1"] * 4,
+        "Metadata_well": ["A01", "A02", "A03", "A04"],
+        "Metadata_cqc_clustered_nuclei": [False, True, False, False],
+        "Cells_x": [0, 1000, 1, 2],
+        "Nuclei_y": [10, 9999, 20, 30],
+    })
+
+    normalize_result = normalize(
+        profiles=profiles,
+        features="infer",
+        meta_features="infer",
+        samples="all",
+        method="standardize",
+        drop_qc_rows=True,
+    )
+
+    expected_result = pd.DataFrame(
+        {
+            "Metadata_plate": ["plate_1"] * 3,
+            "Metadata_well": ["A01", "A03", "A04"],
+            "Metadata_cqc_clustered_nuclei": [False, False, False],
+            "Cells_x": [-1.224744871391589, 0.0, 1.224744871391589],
+            "Nuclei_y": [-1.224744871391589, 0.0, 1.224744871391589],
+        },
+        index=[0, 2, 3],
+    )
+
+    pd.testing.assert_frame_equal(normalize_result, expected_result)
+
+
 def test_normalize_robustize_allsamples():
     """
     Testing normalize pycytominer function

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -461,6 +461,7 @@ def test_normalize_drop_cosmicqc_rows_before_normalization():
 
     pd.testing.assert_frame_equal(normalize_result, expected_result)
 
+
 def test_normalize_drop_cosmicqc_rows_error_when_qc_columns_missing():
     """
     Testing the normalize pycytominer function
@@ -483,6 +484,7 @@ def test_normalize_drop_cosmicqc_rows_error_when_qc_columns_missing():
             method="standardize",
             drop_cosmicqc_rows=True,
         )
+
 
 def test_normalize_drop_cosmicqc_rows_drops_rows_with_true():
     """
@@ -507,6 +509,7 @@ def test_normalize_drop_cosmicqc_rows_drops_rows_with_true():
             method="standardize",
             drop_cosmicqc_rows=True,
         )
+
 
 def test_normalize_drop_cosmicqc_rows_multiple_qc_columns():
     """
@@ -546,6 +549,7 @@ def test_normalize_drop_cosmicqc_rows_multiple_qc_columns():
     )
 
     pd.testing.assert_frame_equal(normalize_result, expected_result)
+
 
 def test_normalize_robustize_allsamples():
     """

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -434,7 +434,7 @@ def test_normalize_drop_qc_rows_before_normalization():
     profiles = pd.DataFrame({
         "Metadata_plate": ["plate_1"] * 4,
         "Metadata_well": ["A01", "A02", "A03", "A04"],
-        "Metadata_cqc_clustered_nuclei": [False, True, False, False],
+        "Metadata_cqc_clustered_nuclei_is_outlier": [False, True, False, False],
         "Cells_x": [0, 1000, 1, 2],
         "Nuclei_y": [10, 9999, 20, 30],
     })
@@ -452,7 +452,7 @@ def test_normalize_drop_qc_rows_before_normalization():
         {
             "Metadata_plate": ["plate_1"] * 3,
             "Metadata_well": ["A01", "A03", "A04"],
-            "Metadata_cqc_clustered_nuclei": [False, False, False],
+            "Metadata_cqc_clustered_nuclei_is_outlier": [False, False, False],
             "Cells_x": [-1.224744871391589, 0.0, 1.224744871391589],
             "Nuclei_y": [-1.224744871391589, 0.0, 1.224744871391589],
         },


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

In this PR, a new parameter called `drop_qc_rows` is added to the normalize function to find columns from coSMicQC with `Metadata_cqc` prefix and drop rows that failed QC. The expectation is that a user would have annotated their profiles with the coSMicQC `qc.parquet` and would not want to normalize their data using those failed cells.

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add option to remove QC‑flagged rows before normalization so flagged samples are excluded from scaling; if QC flags are requested but none are present, an error is raised.

* **Tests**
  * Added tests verifying QC‑flagged rows are filtered (including multiple QC columns), remaining samples are standardized correctly, and appropriate errors occur when QC columns are missing or all rows would be dropped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cytomining/pycytominer/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->