### PR TITLE
bump: version 1.5.0 → 1.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.14"
+    rev: "v0.15.15"
     hooks:
     -   id: ruff-check
         exclude: tutorials/nbconverted/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v1.5.1 (2026-05-28)
+
+[Detailed release notes](https://github.com/cytomining/pycytominer/releases/tag/v1.5.1)
+
+### Feat
+
+- **normalize**: add `drop_cosmicqc_rows` parameter to drop coSMicQC-flagged cells before normalization (#682)
+
+### Docs
+
+- add introduction to pycytominer tutorial with simulated pipeline walkthrough (#681)
+- add single-cell QC profiling tutorial demonstrating CytoTable + coSMicQC + Pycytominer workflow
+
+### Build
+
+- prune test data, media, and walkthroughs from PyPI sdist to reduce package size (#683)
+
 ## v1.5.0 (2026-05-21)
 
 [Detailed release notes](https://github.com/cytomining/pycytominer/releases/tag/v1.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### Docs
 
 - add introduction to pycytominer tutorial with simulated pipeline walkthrough (#681)
-- add single-cell QC profiling tutorial demonstrating CytoTable + coSMicQC + Pycytominer workflow
 
 ### Build
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -87,7 +87,7 @@ authors:
     orcid: https://orcid.org/0000-0002-0503-9348
 title: "Reproducible image-based profiling with Pycytominer"
 # This version is updated using `cz bump` command
-version: "1.5.0"
+version: "1.5.1"
 license: BSD-3-Clause
 repository-code: "https://github.com/cytomining/pycytominer"
 doi: 10.1038/s41592-025-02611-8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ ignore_missing_imports = true
 
 [tool.commitizen]
 # This version is used for changelog tracking and is updated using `cz bump`
-version = "1.5.0"
+version = "1.5.1"
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "pep440"


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_ -->

# Description

Bumping version

## What is the nature of your change?

- [ ] Bug fix (fixes an issue).
- [x] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have deleted all non-relevant text in this pull request template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `drop_cosmicqc_rows` option to normalization to exclude coSMicQC-flagged cells.

* **Documentation**
  * Added a pycytominer tutorial.
  * Added a single-cell QC profiling walkthrough (CytoTable + coSMicQC + pycytominer).

* **Chores**
  * Bumped package version to v1.5.1.
  * Reduced distributed package size by pruning test data and walkthrough media.
  * Updated development lint tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cytomining/pycytominer/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->