### PR TITLE
Set uv cache to runner

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -37,9 +37,9 @@ runs:
       # version or the default packages change. Both of the remaining
       # cache keys depend on PY.
       shell: bash
-      run:
-        echo "PY=$((python -VV; pip freeze) | shasum -a 256 | cut -d' ' -f1)" >>
-        $GITHUB_ENV
+      run: |
+        echo "PY=$((python -VV; pip freeze) | shasum -a 256 | cut -d' ' -f1)" >> $GITHUB_ENV
+        echo "UV_CACHE_DIR=${{ runner.temp }}/.cache/uv" >> $GITHUB_ENV
     - name: Cache pre-commit installation
       # The cache key for the pre-commit installation is a hash of the
       # operating system, PY (see above), and the pre-commit config.
@@ -62,7 +62,7 @@ runs:
       with:
         path: |
           .cache
-          .cache/uv
+          ${{ runner.temp }}/.cache/uv
           .venv
         key:
           cache|${{ runner.os }}|${{ runner.arch }}|${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -38,7 +38,7 @@ runs:
       # cache keys depend on PY.
       shell: bash
       run: |
-        echo "PY=$((python -VV; pip freeze) | shasum -a 256 | cut -d' ' -f1)" >> $GITHUB_ENV
+        echo "PY=$( (python -VV; pip freeze) | shasum -a 256 | cut -d' ' -f1)" >> $GITHUB_ENV
         echo "UV_CACHE_DIR=${{ runner.temp }}/.cache/uv" >> $GITHUB_ENV
     - name: Cache pre-commit installation
       # The cache key for the pre-commit installation is a hash of the

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ env:
   PYTEST_ADDOPTS: ${{ github.event.inputs.pytest_addopts }}
   PYTHONIOENCODING: "UTF-8"
   TARGET_PYTHON_VERSION: "3.10"
-  UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
+  UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv # overridden per-job by setup-env action via $GITHUB_ENV
 
 jobs:
   quality-test:
@@ -193,8 +193,6 @@ jobs:
           setup-uv: true
           install-deps: true
       - name: Build
-        env:
-          UV_CACHE_DIR: ${{ runner.temp }}/.cache/uv
         run: uv build
       - name: Get Pycytominer version
         id: get_version

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -193,6 +193,8 @@ jobs:
           setup-uv: true
           install-deps: true
       - name: Build
+        env:
+          UV_CACHE_DIR: ${{ runner.temp }}/.cache/uv
         run: uv build
       - name: Get Pycytominer version
         id: get_version


### PR DESCRIPTION
# Description

The recent build failed https://github.com/cytomining/pycytominer/actions/runs/28299624199/job/83944570843 - here I set the UV env during the build stage.

## What is the nature of your change?

- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

# Checklist

Please ensure that all boxes are checked before indicating that a pull request is ready for review.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have deleted all non-relevant text in this pull request template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI integration test caching by refining how the uv cache directory is handled, including support for caching from the runner’s temporary cache location to speed up and stabilize runs.
  * Updated workflow/action inline notes so the uv cache directory behavior (including per-job overrides) is clearer for future maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->