### PR TITLE
Fix Spherize: compute SVD on transformed (not raw) data (#747)

### DIFF
--- a/pycytominer/operations/transform.py
+++ b/pycytominer/operations/transform.py
@@ -139,7 +139,17 @@ class Spherize(BaseEstimator, TransformerMixin):
         # Get the eigenvalues and eigenvectors of the covariance matrix
         # by computing the SVD on the data matrix
         # https://stats.stackexchange.com/q/134282/8494
-        _, Sigma, Vt = np.linalg.svd(X, full_matrices=True)
+        #
+        # This must be the SVD of X_transformed (the centered/standardized
+        # matrix computed above), not of the raw input X: the derivation
+        # below explicitly assumes "X is mean-centered (zero mean for each
+        # feature)", and for PCA-cor/ZCA-cor X_transformed is additionally
+        # scaled to unit variance. Computing the SVD of the untransformed X
+        # silently breaks that precondition -- the resulting W still runs
+        # without error, but the transformed output is not actually
+        # whitened (cov(XW) != I) whenever X isn't already centered (and,
+        # for the -cor variants, scaled) on its own.
+        _, Sigma, Vt = np.linalg.svd(X_transformed, full_matrices=True)
 
         # if n <= d then Sigma has shape (n,) so it will need to be expanded to
         # d filled with the value r'th element of Sigma

--- a/tests/test_operations/test_transform.py
+++ b/tests/test_operations/test_transform.py
@@ -49,6 +49,41 @@ def test_spherize():
             assert int(result) == expected_result
 
 
+def test_spherize_whitens_data():
+    """The transformed output of Spherize should be white: cov(XW) should
+    be (near) the identity matrix for every method/center combination.
+
+    test_spherize() above only checks this to the nearest integer (via
+    `.round()`), which is far too coarse to catch a whitening bug: it was
+    passing even when `fit()` computed the SVD of the raw, uncentered
+    input instead of the mean-centered (and, for the -cor variants,
+    standardized) data -- see
+    https://github.com/cytomining/pycytominer/issues/747.
+    """
+    rng = np.random.default_rng(0)
+    # An off-origin mean makes an uncentered-SVD bug visible: with
+    # data centered at/near the origin already, `svd(X)` and
+    # `svd(X_transformed)` coincide, masking the bug.
+    data_off_center = pd.DataFrame(
+        rng.normal(loc=100, scale=25, size=(200, 5)),
+        columns=list("abcde"),
+    )
+
+    spherize_methods = ["PCA", "ZCA", "PCA-cor", "ZCA-cor"]
+    for method in spherize_methods:
+        scaler = Spherize(method=method, center=True)
+        scaler = scaler.fit(data_off_center)
+        transform_df = scaler.transform(data_off_center)
+
+        cov = np.cov(transform_df.to_numpy(), rowvar=False)
+        max_abs_deviation_from_identity = np.abs(cov - np.eye(cov.shape[0])).max()
+
+        assert max_abs_deviation_from_identity < 1e-6, (
+            f"method={method}: transformed data is not white "
+            f"(max|cov(Y) - I| = {max_abs_deviation_from_identity})"
+        )
+
+
 def test_low_variance_spherize():
     err_str = "Divide by zero error, make sure low variance columns are removed"
     data_no_variance = data_df.assign(e=1)


### PR DESCRIPTION
## Bug

`Spherize` (PCA/ZCA/PCA-cor/ZCA-cor whitening transform) does not actually whiten its output: `cov(transform(X))` is far from the identity matrix, for every method, whenever the input isn't already centered (and, for the `-cor` variants, standardized) by the caller.

Fixes #747

## Root cause

`Spherize.fit()` builds `X_transformed` (mean-centered, and for `PCA-cor`/`ZCA-cor` additionally standardized) from the input `X`, but then computes the SVD used to build the whitening matrix `self.W` on the raw, untransformed `X`:

```python
_, Sigma, Vt = np.linalg.svd(X, full_matrices=True)
```

The derivation directly above this line in the existing code explicitly assumes *"X is mean-centered (zero mean for each feature)"* -- a precondition silently violated by passing the wrong variable. There's no error and no obviously wrong shape, so the bug is easy to miss: `transform()`'s output looks like a normal DataFrame, it's just not actually white. This matches the reporter's own observation exactly -- pre-centering the input before calling `Spherize` "fixes" ZCA (because a pre-centered `X` and `X_transformed` now coincide), but not ZCA-cor (which additionally needs unit-variance scaling that pre-centering alone doesn't provide).

## Fix

Use `X_transformed` (not `X`) in the SVD call. One-line change.

## Testing

Reproduced the reporter's own diagnostic (`max|cov(transform(X)) - I|`) against the current `main` branch and confirmed the failure:

```
PCA        max|cov(Y)-I| = 0.888968
ZCA        max|cov(Y)-I| = 0.632116
PCA-cor    max|cov(Y)-I| = 0.982251
ZCA-cor    max|cov(Y)-I| = 0.966227
```

With the fix, all four are `~0` (`1e-6` or below).

Added `test_spherize_whitens_data` to `tests/test_operations/test_transform.py`. The existing `test_spherize` only checks whitening to the nearest *integer* (via `.round()` on the covariance matrix before comparing) -- confirmed this passes both **with and without** this fix, i.e. it can't actually catch this bug. The new test uses data with an off-origin mean (so the bug can't hide behind already-near-zero-centered test data) and asserts `max|cov(Y) - I| < 1e-6` for every method. Reverting just the source fix makes the new test fail with `AssertionError: method=PCA: transformed data is not white (max|cov(Y) - I| = 0.987...)`, while the pre-existing (too-coarse) tests still pass either way -- confirming this is a genuine, tighter regression guard.

Ran `pytest tests/test_operations/ tests/test_normalize.py` (covers `Spherize` and its usage via `normalize()`): 73 passed, no failures.

`ruff check` and `ruff format --check` (per `.pre-commit-config.yaml`) are clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data sphering so covariance results remain accurate when centering or standardization is enabled.
  * Corrected handling of off-center input data across supported sphering methods.

* **Tests**
  * Added regression coverage to verify near-identity covariance results for centered, off-center data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->